### PR TITLE
perf: use `-1` offset iso `beginning` for kafka init container

### DIFF
--- a/charts/common/templates/_init.tpl
+++ b/charts/common/templates/_init.tpl
@@ -179,7 +179,7 @@ command:
   - "/bin/sh"
   - "-c"
   - |
-    until kcat -b "${KAFKA_HOSTNAME}:${KAFKA_PORT}" -t kafka-cluster-init -C -o beginning -e
+    until kcat -b "${KAFKA_HOSTNAME}:${KAFKA_PORT}" -t kafka-cluster-init -C -o -1 -e
     do
       sleep 1
     done


### PR DESCRIPTION
Prevent pulling in data from the beginning over the network just to check if kafka is alive.