### PR TITLE
ci: add conventional commit checker

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -30,8 +30,6 @@ jobs:
         uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          wip: true  # Allows to prefix PR with '[WIP]' when draft PRs are not possible
 
       - name: Lint commits
         uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -26,17 +26,19 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Lint PR title
-        if: github.event_name == 'pull_request'
+        if: ${{ !cancelled() && (github.event_name == 'pull_request') }}
         id: lint_pr_title
         uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint commits
+        if: ${{ !cancelled() }}
         id: lint_commits
         uses: wagoid/commitlint-github-action@v5
 
       - name: Add summary
+        if: ${{ !cancelled() }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -6,6 +6,11 @@ on:
       - main
       - releases/**
   pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
 
 permissions:
   contents: read
@@ -19,6 +24,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Lint PR title
+        if: github.event_name == 'pull_request'
+        uses: amannn/action-semantic-pull-request@v5.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true  # Allows to prefix PR with '[WIP]' when draft PRs are not possible
 
       - name: Lint commits
         uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,24 @@
+name: Conventional Commits
+
+on:
+  push:
+    branches:
+      - main
+      - releases/**
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+
+  lint-commits:
+    name: Lint Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Lint commits
+        uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -27,9 +27,70 @@ jobs:
 
       - name: Lint PR title
         if: github.event_name == 'pull_request'
+        id: lint_pr_title
         uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint commits
+        id: lint_commits
         uses: wagoid/commitlint-github-action@v5
+
+      - name: Add summary
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isPr = ${{ github.event_name == 'pull_request' }};
+            const prTitle = "${{ github.event.pull_request.title }}";
+            const lintPrTitleOutcome = "${{ steps.lint_pr_title.outcome }}";
+            const lintCommitsOutput = ${{ steps.lint_commits.outputs.results }};
+
+            const icon = {
+              pass: ":white_check_mark:",
+              fail: ":x:",
+              warn: ":warning:",
+            };
+
+            let result = "";
+            if (lintCommitsOutput.some((item) => item.errors.length !== 0)) {
+              result = icon.fail;
+            } else if (lintCommitsOutput.some((item) => item.warnings.length !== 0)) {
+              result = icon.warn;
+            } else {
+              result = icon.pass;
+            }
+
+            const title = `${result} Conventional Commits`;
+
+            let prDetails = "";
+            if (isPr) {
+              prDetails = `${
+                lintPrTitleOutcome === "success" ? icon.pass : icon.fail
+              } PR title (${prTitle})`;
+            } else {
+              prDetails = "No PR title to lint";
+            }
+
+            let details = [];
+            for (item of lintCommitsOutput) {
+              const commit = item.message;
+              const result = item.errors.length !== 0 ? icon.fail : ((item.warnings.length !== 0) ? icon.warn : icon.pass);
+              const messages = [...item.errors, ...item.warnings].join(", ");
+              const hash = item.hash;
+              details = [...details, [result, commit, messages, hash]];
+            }
+
+            await core.summary
+              .addHeading(title)
+              .addHeading(`${prDetails}`, 4)
+              .addTable([
+                [
+                  { data: "Result", header: true },
+                  { data: "Commit", header: true },
+                  { data: "Messages", header: true },
+                  { data: "Hash", header: true },
+                ],
+                ...details
+              ])
+              .addLink("More info on conventional commits", "https://www.conventionalcommits.org/en/v1.0.0/")
+              .write();


### PR DESCRIPTION
This PR adds conventional commit checks. For PR title updates the action also retriggers to check it again.

An example run of a failure for a commit: https://github.com/accelleran/helm-charts-ng/actions/runs/7904111751
An example run of a failure for a PR title: https://github.com/accelleran/helm-charts-ng/actions/runs/7904544753
