### PR TITLE
fix: prevent deletions for undefined config parts

### DIFF
--- a/charts/cell-wrapper-config/values.yaml
+++ b/charts/cell-wrapper-config/values.yaml
@@ -314,7 +314,11 @@ netconf:
         </cw-ran>
         {{- end }}
       - |-
+        {{- if .Values.global.config.global.configuration }}
         <configuration xmlns="http://accelleran.com/ns/yang/accelleran-cw-config" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="delete"/>
+        {{ else }}
+        <configuration xmlns="http://accelleran.com/ns/yang/accelleran-cw-config" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace"/>
+        {{- end }}
 
   service:
     name: ""

--- a/charts/cell-wrapper-config/values.yaml
+++ b/charts/cell-wrapper-config/values.yaml
@@ -273,13 +273,17 @@ netconf:
         {{ else }}
         <cw-install xmlns="http://accelleran.com/ns/yang/accelleran-cw-install" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
           {{- range $index, $du := .Values.global.config.dus }}
+          {{- if $du.install }}
           <du xc:operation="delete">
             <name>{{ $du.name }}</name>
           </du>
+          {{- end }}
           {{ range $index, $ru := $du.rus }}
+          {{- if $ru.install }}
           <ru xc:operation="delete">
             <name>{{ $ru.name }}</name>
           </ru>
+          {{- end }}
           {{- end }}
           {{- end }}
         </cw-install>
@@ -290,13 +294,17 @@ netconf:
         {{ else }}
         <cw-internal xmlns="http://accelleran.com/ns/yang/accelleran-cw-internal" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
           {{- range $index, $du := .Values.global.config.dus }}
+          {{- if $du.internal }}
           <du xc:operation="delete">
             <name>{{ $du.name }}</name>
           </du>
+          {{- end }}
           {{ range $index, $ru := $du.rus }}
+          {{- if $ru.internal }}
           <ru xc:operation="delete">
             <name>{{ $ru.name }}</name>
           </ru>
+          {{- end }}
           {{- end }}
           {{- end }}
         </cw-internal>
@@ -307,9 +315,11 @@ netconf:
         {{ else }}
         <cw-ran xmlns="http://accelleran.com/ns/yang/accelleran-cw-ran" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
           {{- range $index, $du := .Values.global.config.dus }}
+          {{- if $du.ran }}
           <du xc:operation="delete">
             <name>{{ $du.name }}</name>
           </du>
+          {{- end }}
           {{- end }}
         </cw-ran>
         {{- end }}


### PR DESCRIPTION
When for example leaving RAN configuration for the dashboard, the cell-wrapper-config chart won't be deleting that configuration (as it would be undefined in the values file). That way there would be persistence of the RAN model and still the possibility to upgrade the install model through `cell-wrapper-config`.