### PR TITLE
ci: enable drax chart install tests

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -243,6 +243,7 @@ jobs:
               format('--charts "{0}"', needs.vars.outputs.charts_to_test)
             )
           }}
+          --helm-extra-set-args "--set=kafka.provisioning.useHelmHooks=false"
 
   release-charts:
     name: Release Charts

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -886,3 +886,6 @@ kminion:
 
       logger:
         level: info
+
+  tests:
+    enabled: false

--- a/etc/ct.yaml
+++ b/etc/ct.yaml
@@ -6,5 +6,5 @@ lint-conf: "etc/lintconf.yaml"
 validate-chart-schema: true
 chart-yaml-schema: "etc/chart_schema.yaml"
 validate-maintainers: false
-helm-extra-args: --timeout 300s --debug
-kubectl-timeout: 300s
+helm-extra-args: --timeout 600s --debug
+kubectl-timeout: 600s


### PR DESCRIPTION
This PR enables the `ct install` tests for the `drax` chart.

The timeout of 10 minutes isn't really necessary for the github hosted runners (the whole `ct install` command was done within 3 minutes for just the `drax` chart), but for local runs without cached images it took about 9 minutes.

- About 40 seconds to build the dependencies
- About 12 seconds for the templating (during the `helm install`)
- About 7 minutes from applying the templates until all pods running
- Remainder to run the tests, gather all resource descriptions/logs/..., to delete all resources, ...
