### PR TITLE
chore: add node selector values

### DIFF
--- a/charts/drax/values-node-selector.yaml
+++ b/charts/drax/values-node-selector.yaml
@@ -1,0 +1,67 @@
+global:
+  nodeSelector:
+    drax.accelleran.com/schedule: "true"
+
+kafka:
+  controller:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+  broker:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+  metrics:
+    kafka:
+      nodeSelector:
+        drax.accelleran.com/schedule: "true"
+  provisioning:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+
+nats:
+  podTemplate:
+    merge:
+      spec:
+        nodeSelector:
+          drax.accelleran.com/schedule: "true"
+
+redis:
+  master:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+  replica:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+
+prometheus:
+  nodeSelector:
+    drax.accelleran.com/schedule: "true"
+  prometheus-pushgateway:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+  kube-state-metrics:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+
+grafana:
+  nodeSelector:
+    drax.accelleran.com/schedule: "true"
+
+loki-stack:
+  loki:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+
+influxdb:
+  nodeSelector:
+    drax.accelleran.com/schedule: "true"
+  backup:
+    nodeSelector:
+      drax.accelleran.com/schedule: "true"
+
+vector:
+  nodeSelector:
+    drax.accelleran.com/schedule: "true"
+
+kminion:
+  nodeSelector:
+    drax.accelleran.com/schedule: "true"

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -30,6 +30,7 @@ global:
     enabled: true
     secretName: "accelleran-license"
 
+  nodeSelector: {}
 
 bootstrap:
   create: true
@@ -248,17 +249,20 @@ kafka:
   controller:
     replicaCount: 3
     automountServiceAccountToken: true
+    nodeSelector: {}
     persistence:
       size: 1Gi
 
   broker:
     automountServiceAccountToken: true
+    nodeSelector: {}
     persistence:
       size: 1Gi
 
   provisioning:
     enabled: true
     automountServiceAccountToken: true
+    nodeSelector: {}
     replicationFactor: 1
     numPartitions: 1
     topics:
@@ -301,6 +305,7 @@ kafka:
     kafka:
       enabled: false
       automountServiceAccountToken: true
+      nodeSelector: {}
 
     jmx:
       enabled: true
@@ -363,8 +368,11 @@ redis:
     enabled: false
 
   master:
+    nodeSelector: {}
     persistence:
       size: 1Gi
+  replica:
+    nodeSelector: {}
 
 
 prometheus:
@@ -376,6 +384,12 @@ prometheus:
 
   prometheus-node-exporter:
     enabled: true
+
+  prometheus-pushgateway:
+    nodeSelector: {}
+
+  kube-state-metrics:
+    nodeSelector: {}
 
   serviceAccounts:
     kubeStateMetrics:
@@ -621,6 +635,10 @@ influxdb:
   podLabels:
     drax/role: ric
     drax/component-name: influxdb
+  
+  nodeSelector: {}
+  backup:
+    nodeSelector: {}
 
   persistence:
     enabled: true
@@ -659,6 +677,8 @@ vector:
   fullnameOverride: ""
 
   role: "Stateless-Aggregator"
+
+  nodeSelector: {}
 
   image:
     repository: timberio/vector
@@ -853,6 +873,8 @@ vector:
 
 kminion:
   enabled: true
+
+  nodeSelector: {}
 
   kminion:
     # See reference config: https://github.com/cloudhut/kminion/blob/master/docs/reference-config.yaml

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -635,7 +635,7 @@ influxdb:
   podLabels:
     drax/role: ric
     drax/component-name: influxdb
-  
+
   nodeSelector: {}
   backup:
     nodeSelector: {}


### PR DESCRIPTION
This PR adds a values file that can be downloaded and applied in addition to what's normally set.

Currently the label `drax.accelleran.com/schedule: "true"` should be set on all nodes that are desired to run dRAX on.

```sh
kubectl label nodes <node-names> drax.accelleran.com/schedule=true
```

Deployment could then look like this for example:

```sh
curl -O https://raw.githubusercontent.com/accelleran/helm-charts-ng/node-selector/charts/drax/values-node-selector.yaml
helm upgrade --install drax accelleran/drax --values values-node-selector.yaml --values custom-values.yaml
```
