### PR TITLE
feat: add smo-api service

### DIFF
--- a/charts/drax/templates/service-smo-api.yaml
+++ b/charts/drax/templates/service-smo-api.yaml
@@ -1,0 +1,26 @@
+{{- include
+      "accelleran.common.service"
+      (fromYaml (include "accelleran.drax.smo.api.service.args" $))
+-}}
+
+
+{{- define "accelleran.drax.smo.api.service.args" -}}
+{{- $ := . -}}
+{{- $values := index $.Values "dashboard" -}}
+
+top:
+  {{ $ | toYaml | nindent 2 }}
+values:
+  {{ (mergeOverwrite (unset (deepCopy $values) "service") (fromYaml (include "accelleran.drax.smo.api.service.valueOverrides" $))) | toYaml | nindent 2 }}
+
+name: {{ printf "%s-smo-api" $.Release.Name | quote }}
+{{- end -}}
+
+
+{{- define "accelleran.drax.smo.api.service.valueOverrides" -}}
+{{- $ := . -}}
+{{- $values := $.Values.smo.api -}}
+
+service:
+  {{ $values.service | toYaml | nindent 2 }}
+{{- end -}}

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -49,6 +49,21 @@ bootstrap:
     port: 0
 
 
+smo:
+  api:
+    service:
+      enabled: true
+      name: ""
+      type: ClusterIP
+      ports:
+        http:
+          port: 5000
+          targetPort: 5000
+          nodePort: null
+          protocol: TCP
+          appProtocol: http
+
+
 dashboard:
   enabled: true
 


### PR DESCRIPTION
There is now a separate service `drax-smo-api`. I've removed the websocket port with the `unset` function. It looks a bit complex in combination with the overriding of the values of the dashboard chart, but that's necessary to make sure the label selector will be correct for matching with the dashboard pod... This would be way more readable if we would have a separated dashboard and api server.
