### PR TITLE
feat: add anonymous access to grafana dashboards

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -481,6 +481,8 @@ grafana:
   adminPassword: accelleran
 
   grafana.ini:
+    auth.basic:
+      enabled: false
     auth.anonymous:
       enabled: true
       # Organization name that should be used for unauthenticated users

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -480,6 +480,14 @@ grafana:
   adminUser: accelleran
   adminPassword: accelleran
 
+  grafana.ini:
+    auth.anonymous:
+      enabled: true
+      # Organization name that should be used for unauthenticated users
+      org_name: Main Org.
+      # Role for unauthenticated users, other valid values are `Editor` and `Admin`
+      org_role: Viewer
+
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
This PR adds anonymous access to the dashboards as a "Viewer". To prevent the redirection to the login page, basic authentication needs to be disabled.