### PR TITLE
fix!: disable NATS/Redis in CU by default

### DIFF
--- a/charts/cu-cp/ci/ci-values.yaml
+++ b/charts/cu-cp/ci/ci-values.yaml
@@ -1,0 +1,5 @@
+nats:
+  enabled: true
+
+redis:
+  enabled: true

--- a/charts/cu-cp/values.yaml
+++ b/charts/cu-cp/values.yaml
@@ -458,13 +458,13 @@ ds-ctrl:
   affinity: {}
 
 nats:
-  enabled: true
+  enabled: false
 
   natsBox:
     enabled: false
 
 redis:
-  enabled: true
+  enabled: false
 
   architecture: standalone
   auth:

--- a/charts/cu-up/ci/ci-values.yaml
+++ b/charts/cu-up/ci/ci-values.yaml
@@ -1,0 +1,5 @@
+nats:
+  enabled: true
+
+redis:
+  enabled: true

--- a/charts/cu-up/values.yaml
+++ b/charts/cu-up/values.yaml
@@ -305,13 +305,13 @@ xdp-ups:
   affinity: {}
 
 nats:
-  enabled: true
+  enabled: false
 
   natsBox:
     enabled: false
 
 redis:
-  enabled: true
+  enabled: false
 
   architecture: standalone
   auth:


### PR DESCRIPTION
These dependencies are enabled during Chart Testing thanks to the values files added to the two `ci` folders, now included in both CU-CP and CU-UP charts.