### PR TITLE
chore: update drax subchart dependencies with migration to helm-charts

### DIFF
--- a/charts/drax/charts/config-api/Chart.lock
+++ b/charts/drax/charts/config-api/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:47:54.387641195Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:07:30.908162318+01:00"

--- a/charts/drax/charts/dashboard/Chart.lock
+++ b/charts/drax/charts/dashboard/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:47:45.542776073Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:08:02.81791388+01:00"

--- a/charts/drax/charts/e2-t/Chart.lock
+++ b/charts/drax/charts/e2-t/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
   version: 18.18.0
-digest: sha256:3b87d2a02904802f1df5d72e9de8cbeaefd7d79d733de58b890ecf82c91b6eb4
-generated: "2024-03-06T11:47:31.713876062Z"
+digest: sha256:2815544741fead3a8a9e37044ebcb85eb8112b59f57f1e90f8b376a33226a575
+generated: "2024-03-06T15:08:09.484246836+01:00"

--- a/charts/drax/charts/golang-nkafka/Chart.lock
+++ b/charts/drax/charts/golang-nkafka/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:47:20.879139797Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:08:16.991173104+01:00"

--- a/charts/drax/charts/network-state-monitor/Chart.lock
+++ b/charts/drax/charts/network-state-monitor/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:47:14.096524412Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:08:21.979967685+01:00"

--- a/charts/drax/charts/pm-counters/Chart.lock
+++ b/charts/drax/charts/pm-counters/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:47:06.970608764Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:08:26.981588375+01:00"

--- a/charts/drax/charts/service-monitor/Chart.lock
+++ b/charts/drax/charts/service-monitor/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:47:00.262780184Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:08:32.953537548+01:00"

--- a/charts/drax/charts/service-orchestrator/Chart.lock
+++ b/charts/drax/charts/service-orchestrator/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.2
-digest: sha256:b385f060d3fcb0faabcef6dd5911852ae818734bdb5183e61fbdb257c73a4e53
-generated: "2024-03-06T11:46:53.414419814Z"
+digest: sha256:128d4d3cbc5a7a0a3514250d5c940063153d4664c4afba07dab3187d7acf9402
+generated: "2024-03-06T15:08:37.910476975+01:00"


### PR DESCRIPTION
This should fix the failing lint tests.