### PR TITLE
fix: only update index.html if diff exists

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -282,9 +282,11 @@ jobs:
         run: |-
           git checkout gh-pages
           helm repo-html
-          git add index.html
-          git commit -s -m "Update index.html"
-          git push
+          if ! git diff --exit-code index.html > /dev/null 2>&1 ; then
+            git add index.html
+            git commit -s -m "Update index.html"
+            git push
+          fi
           git checkout -
 
   release-please:


### PR DESCRIPTION
Fixes the release step failing if there is no update to the index.html file.