### PR TITLE
feat: add DU metrics server

### DIFF
--- a/charts/du-metrics-server/.helmignore
+++ b/charts/du-metrics-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/du-metrics-server/Chart.lock
+++ b/charts/du-metrics-server/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: common
+  repository: https://accelleran.github.io/helm-charts/
+  version: 0.2.2
+- name: influxdb2
+  repository: https://helm.influxdata.com/
+  version: 2.1.2
+digest: sha256:af889cd34ab190d5b7797ff0d8f4b71f43c6650d1570440fa71bf50f4322c28e
+generated: "2024-04-10T11:21:38.64493959+02:00"

--- a/charts/du-metrics-server/Chart.yaml
+++ b/charts/du-metrics-server/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: du-metrics-server
+description: Accelleran's DU metrics server
+type: application
+version: 0.1.0
+appVersion: "edge"
+dependencies:
+  - name: common
+    version: 0.2.2
+    repository: https://accelleran.github.io/helm-charts/
+  - name: influxdb2
+    alias: influxdb
+    condition: influxdb.enabled
+    version: 2.1.2
+    repository: https://helm.influxdata.com/

--- a/charts/du-metrics-server/templates/NOTES.txt
+++ b/charts/du-metrics-server/templates/NOTES.txt
@@ -1,0 +1,14 @@
+################################################################################
+
+Accelleran DU Metrics Server {{ $.Chart.Version }}
+
+Deployed Accelleran DU Metrics Server components [{{ $.Release.Name }}]
+with the following details:
+
+  Tag: {{ include "accelleran.common.appVersion" (dict "top" $) }}
+
+Discover the IPs given to the services using the following command and
+its EXTERNAL-IP column:
+  $ kubectl get service
+
+################################################################################

--- a/charts/du-metrics-server/templates/_helper.tpl
+++ b/charts/du-metrics-server/templates/_helper.tpl
@@ -1,0 +1,39 @@
+{{/*
+Init container check waiting until influxdb is available
+*/}}
+{{- define "accelleran.du-metrics-server.init.influxdb" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to du metrics server init influxdb" -}}
+
+{{ include "accelleran.common.init.container"
+    (include "accelleran.du-metrics-server.init.influxdb.args" . | fromYaml)
+}}
+{{- end -}}
+
+
+{{- define "accelleran.du-metrics-server.init.influxdb.args" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to du metrics server init influxdb args" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{- $image := ($values.initImage).influxdb | required "The influxdb init image needs to be provided to du metrics server init influxdb args" -}}
+
+top:
+  {{ $ | toYaml | nindent 2 }}
+values:
+  {{
+    (mergeOverwrite
+      (deepCopy $values)
+      (dict "image" $image)
+    ) | toYaml | nindent 2
+  }}
+
+name: check-influxdb
+command:
+- "/bin/sh"
+- "-c"
+- |
+    until (timeout 10s curl -sL -I {{ printf "http://%s/ping?wait_for_leader=5s" (printf "%s.%s:%v" ($.Values.influxdb.fullnameOverride | default (printf "%s-%s" $.Release.Name ($.Values.influxdb.nameOverride | default "influxdb"))) $.Release.Namespace $.Values.influxdb.service.port) }} > /dev/null 2>&1)
+    do
+        sleep 1
+    done
+    echo "$(date) InfluxDB ready"
+{{- end -}} 

--- a/charts/du-metrics-server/templates/deployment.yaml
+++ b/charts/du-metrics-server/templates/deployment.yaml
@@ -1,0 +1,35 @@
+{{- include
+      "accelleran.common.deployment"
+      (fromYaml (include "accelleran.du-metrics-server.deployment.args" $))
+-}}
+
+{{- define "accelleran.du-metrics-server.deployment.args" -}}
+{{- $ := . -}}
+{{- $values := index $.Values "du-metrics-server" -}}
+{{- $fullname := include "accelleran.common.fullname" (dict "top" $ "values" $values) -}}
+
+top:
+  {{ $ | toYaml | nindent 2 }}
+values:
+  {{ $values | toYaml | nindent 2 }}
+
+initContainers:
+- {{ fromYaml (include "accelleran.du-metrics-server.init.influxdb" (dict "top" $ "values" (index $.Values "du-metrics-server"))) | toYaml | nindent 2 }}
+
+env:
+  - name: PORT
+    value: {{ (($values.service.ports).metric).containerPort | default ((($values.service).ports).metric).targetPort | default ((($values.service).ports).metric).port | quote }}
+  - name: TESTBED
+    value: {{ $values.config.testbed | quote }}
+  - name: URL
+    value: {{ printf "http://%s.%s:%v" (($.Values.influxdb).fullnameOverride | default (printf "%s-%s" $.Release.Name (($.Values.influxdb).nameOverride | default "influxdb"))) $.Release.Namespace (($.Values.influxdb).service).port }}
+  - name: ORG
+    value: {{ (($.Values.influxdb).adminUser).organization }}
+  - name: BUCKET
+    value: {{ (($.Values.influxdb).adminUser).bucket | quote }}
+  - name: TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: {{ (($.Values.influxdb).adminUser).existingSecret | default (printf "%s-auth" (($.Values.influxdb).fullnameOverride | default (printf "%s-%s" $.Release.Name (($.Values.influxdb).nameOverride | default "influxdb")))) }}
+        key: admin-token
+{{- end -}}

--- a/charts/du-metrics-server/templates/service.yaml
+++ b/charts/du-metrics-server/templates/service.yaml
@@ -1,0 +1,7 @@
+{{- include
+      "accelleran.common.service"
+      (dict
+        "top" $
+        "values" (index $.Values "du-metrics-server")
+      )
+-}}

--- a/charts/du-metrics-server/values.yaml
+++ b/charts/du-metrics-server/values.yaml
@@ -74,8 +74,8 @@ influxdb:
     bucket: "default"
     retention_policy: "0s"
     user: "admin"
-    password: "password"
-    token: "ubZW5JVsnhjaLTMeBSYVjvTc4pkJ5jPYk8Tqkj2R9j28Ern4kaZP4yPo4bHbLfYG"
+    password: ""
+    token: ""
     # existingSecret: influxdb-auth
 
   persistence:

--- a/charts/du-metrics-server/values.yaml
+++ b/charts/du-metrics-server/values.yaml
@@ -1,0 +1,94 @@
+du-metrics-server:
+  config:
+    testbed: default
+
+  replicaCount: 1
+
+  initImage:
+    influxdb:
+      repository: accelleran/acc-generic-img
+      pullPolicy: IfNotPresent
+      tag: "0.8.0"
+
+  image:
+    repository: accelleran/du-metrics-server
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  accelleranLicense:
+    enabled: false
+
+  extraEnvs: []
+
+  extraLabels: {}
+  annotations: {}
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  service:
+    enabled: true
+    name: ""
+    type: NodePort
+    ports:
+      metric:
+        port: 55555
+        targetPort: 55555
+        nodePort: 31555
+        protocol: UDP
+
+
+influxdb:
+  enabled: true
+
+  adminUser:
+    organization: "accelleran"
+    bucket: "default"
+    retention_policy: "0s"
+    user: "admin"
+    password: "password"
+    token: "ubZW5JVsnhjaLTMeBSYVjvTc4pkJ5jPYk8Tqkj2R9j28Ern4kaZP4yPo4bHbLfYG"
+    # existingSecret: influxdb-auth
+
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    mountPath: /var/lib/influxdb2
+    subPath: ""
+
+  service:
+    annotations: {}
+    labels: {}
+    type: ClusterIP
+    portName: http
+    port: 80
+    targetPort: 8086

--- a/etc/.release-please-manifest.json
+++ b/etc/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "charts/cell-wrapper-config": "0.2.5",
   "charts/cu-cp": "7.0.0",
   "charts/cu-up": "7.0.0",
-  "charts/drax": "7.1.0"
+  "charts/drax": "7.1.0",
+  "charts/du-metrics-server": "0.1.0"
 }

--- a/etc/release-please-config.json
+++ b/etc/release-please-config.json
@@ -37,6 +37,10 @@
     "charts/drax": {
       "component": "drax",
       "package-name": "drax"
+    },
+    "charts/du-metrics-server": {
+      "component": "du-metrics-server",
+      "package-name": "du-metrics-server"
     }
   }
 }


### PR DESCRIPTION
This PR adds the infrastructure for DU metrics.

Currently it consists of multiple commits which should be separated out in order to successfully merge this. Reason being that the du-metrics-server chart needs to be added first and released before it can be included in the drax chart (the CI will fail until this PR is cleaned up to just add that new chart). The overall picture needs to be reviewed though, hence this way of working.

As mentioned above, there will be one new chart `du-metrics-server` which will deploy a metrics server that's exposed globally through a nodeport for all DUs to connect to. That server will push data in influxdb. This is a separate instance as the one we already have in the drax charts (as it's more up-to-date).

The grafana dashboard will be extended quite soon as well, but for now just the base is included to get going.

Edit: the dashboard is now updated with extra panels etc.