### PR TITLE
fix: flatten xml

### DIFF
--- a/charts/cell-wrapper-config/values.yaml
+++ b/charts/cell-wrapper-config/values.yaml
@@ -201,67 +201,67 @@ netconf:
     config:
       - |-
         <cw-install xmlns="http://accelleran.com/ns/yang/accelleran-cw-install" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
-          {{- range $index, $du := .Values.global.config.dus }}
-          <du xc:operation="replace">
-            <name>{{ $du.name }}</name>
-            {{- with $du.install }}
-            {{- . | nindent 4 }}
-            {{- end }}
-          </du>
-          {{ range $index, $ru := $du.rus }}
-          <ru xc:operation="replace">
-            <name>{{ $ru.name }}</name>
-            {{- with $ru.install }}
-            {{- . | nindent 4 }}
-            {{- end }}
-            <du>{{ $du.name }}</du>
-          </ru>
-          {{- end }}
-          {{- end }}
-          {{- with .Values.global.config.global.install }}
-          {{ . | nindent 2 }}
-          {{- end }}
+        {{- range $index, $du := .Values.global.config.dus }}
+        <du xc:operation="replace">
+        <name>{{ $du.name }}</name>
+        {{- with $du.install }}
+        {{ . }}
+        {{- end }}
+        </du>
+        {{ range $index, $ru := $du.rus }}
+        <ru xc:operation="replace">
+        <name>{{ $ru.name }}</name>
+        {{- with $ru.install }}
+        {{ . }}
+        {{- end }}
+        <du>{{ $du.name }}</du>
+        </ru>
+        {{- end }}
+        {{- end }}
+        {{- with .Values.global.config.global.install }}
+        {{ . }}
+        {{- end }}
         </cw-install>
       - |-
         <cw-internal xmlns="http://accelleran.com/ns/yang/accelleran-cw-internal" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
-          {{- range $index, $du := .Values.global.config.dus }}
-          <du xc:operation="replace">
-            <name>{{ $du.name }}</name>
-            {{- with $du.internal }}
-            {{- . | nindent 4 }}
-            {{- end }}
-          </du>
-          {{ range $index, $ru := $du.rus }}
-          <ru xc:operation="replace">
-            <name>{{ $ru.name }}</name>
-            {{- with $ru.internal }}
-            {{- . | nindent 4 }}
-            {{- end }}
-          </ru>
-          {{- end }}
-          {{- end }}
-          {{- with .Values.global.config.global.internal }}
-          {{ . | nindent 2}}
-          {{- end }}
+        {{- range $index, $du := .Values.global.config.dus }}
+        <du xc:operation="replace">
+        <name>{{ $du.name }}</name>
+        {{- with $du.internal }}
+        {{ . }}
+        {{- end }}
+        </du>
+        {{ range $index, $ru := $du.rus }}
+        <ru xc:operation="replace">
+        <name>{{ $ru.name }}</name>
+        {{- with $ru.internal }}
+        {{ . }}
+        {{- end }}
+        </ru>
+        {{- end }}
+        {{- end }}
+        {{- with .Values.global.config.global.internal }}
+        {{ . }}
+        {{- end }}
         </cw-internal>
       - |-
         <cw-ran xmlns="http://accelleran.com/ns/yang/accelleran-cw-ran" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
-          {{- range $index, $du := .Values.global.config.dus }}
-          <du xc:operation="replace">
-            <name>{{ $du.name }}</name>
-            {{- with $du.ran }}
-            {{- . | nindent 4 }}
-            {{- end }}
-          </du>
-          {{- end }}
-          {{- with .Values.global.config.global.ran }}
-          {{ . | nindent 2 }}
-          {{- end }}
+        {{- range $index, $du := .Values.global.config.dus }}
+        <du xc:operation="replace">
+        <name>{{ $du.name }}</name>
+        {{- with $du.ran }}
+        {{- . }}
+        {{- end }}
+        </du>
+        {{- end }}
+        {{- with .Values.global.config.global.ran }}
+        {{ . }}
+        {{- end }}
         </cw-ran>
       - |-
         <configuration xmlns="http://accelleran.com/ns/yang/accelleran-cw-config" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
           {{- with .Values.global.config.global.configuration }}
-          {{ . | nindent 2}}
+          {{ . }}
           {{- end }}
         </configuration>
 
@@ -272,20 +272,20 @@ netconf:
         <cw-install xmlns="http://accelleran.com/ns/yang/accelleran-cw-install" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="delete"/>
         {{ else }}
         <cw-install xmlns="http://accelleran.com/ns/yang/accelleran-cw-install" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
-          {{- range $index, $du := .Values.global.config.dus }}
-          {{- if $du.install }}
-          <du xc:operation="delete">
-            <name>{{ $du.name }}</name>
-          </du>
-          {{- end }}
-          {{ range $index, $ru := $du.rus }}
-          {{- if $ru.install }}
-          <ru xc:operation="delete">
-            <name>{{ $ru.name }}</name>
-          </ru>
-          {{- end }}
-          {{- end }}
-          {{- end }}
+        {{- range $index, $du := .Values.global.config.dus }}
+        {{- if $du.install }}
+        <du xc:operation="delete">
+        <name>{{ $du.name }}</name>
+        </du>
+        {{- end }}
+        {{ range $index, $ru := $du.rus }}
+        {{- if $ru.install }}
+        <ru xc:operation="delete">
+        <name>{{ $ru.name }}</name>
+        </ru>
+        {{- end }}
+        {{- end }}
+        {{- end }}
         </cw-install>
         {{- end }}
       - |-
@@ -293,20 +293,20 @@ netconf:
         <cw-internal xmlns="http://accelleran.com/ns/yang/accelleran-cw-internal" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="delete"/>
         {{ else }}
         <cw-internal xmlns="http://accelleran.com/ns/yang/accelleran-cw-internal" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
-          {{- range $index, $du := .Values.global.config.dus }}
-          {{- if $du.internal }}
-          <du xc:operation="delete">
-            <name>{{ $du.name }}</name>
-          </du>
-          {{- end }}
-          {{ range $index, $ru := $du.rus }}
-          {{- if $ru.internal }}
-          <ru xc:operation="delete">
-            <name>{{ $ru.name }}</name>
-          </ru>
-          {{- end }}
-          {{- end }}
-          {{- end }}
+        {{- range $index, $du := .Values.global.config.dus }}
+        {{- if $du.internal }}
+        <du xc:operation="delete">
+        <name>{{ $du.name }}</name>
+        </du>
+        {{- end }}
+        {{ range $index, $ru := $du.rus }}
+        {{- if $ru.internal }}
+        <ru xc:operation="delete">
+        <name>{{ $ru.name }}</name>
+        </ru>
+        {{- end }}
+        {{- end }}
+        {{- end }}
         </cw-internal>
         {{- end }}
       - |-
@@ -314,13 +314,13 @@ netconf:
         <cw-ran xmlns="http://accelleran.com/ns/yang/accelleran-cw-ran" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="delete"/>
         {{ else }}
         <cw-ran xmlns="http://accelleran.com/ns/yang/accelleran-cw-ran" xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="replace">
-          {{- range $index, $du := .Values.global.config.dus }}
-          {{- if $du.ran }}
-          <du xc:operation="delete">
-            <name>{{ $du.name }}</name>
-          </du>
-          {{- end }}
-          {{- end }}
+        {{- range $index, $du := .Values.global.config.dus }}
+        {{- if $du.ran }}
+        <du xc:operation="delete">
+        <name>{{ $du.name }}</name>
+        </du>
+        {{- end }}
+        {{- end }}
         </cw-ran>
         {{- end }}
       - |-


### PR DESCRIPTION
This allows to inject yaml in `extra-config` for example without having 4 additional spaces of indentation.