### PR TITLE
ci: add pull to render index.html in same run as index.yaml

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -281,6 +281,7 @@ jobs:
       - name: Generate repo html index
         run: |-
           git checkout gh-pages
+          git pull # pull index.yaml commit from chart releaser
           helm repo-html
           if ! git diff --exit-code index.html > /dev/null 2>&1 ; then
             git add index.html


### PR DESCRIPTION
Originally this PR's title was `ci: add pull to prevent rejected updates on push`. But that's not the main issue that's solved with the pull.

In the same run of chart releaser there is no diff found on `index.yaml` as those changes haven't been checked out. Thus during the run there is one commit with an additional release unknown (which the pull would solve). Thus the html also doesn't have any changes.

The following [run](https://github.com/accelleran/helm-charts/actions/runs/8880669394/job/24381688587#step:8:1) brought this all up:

```
Run git checkout gh-pages
  git checkout gh-pages
  helm repo-html
  if ! git diff --exit-code index.html > /dev/null 2>&1 ; then
    git add index.html
    git commit -s -m "Update index.html"
    git push
  fi
  git checkout -
  shell: /usr/bin/bash -e {0}
Switched to a new branch 'gh-pages'
branch 'gh-pages' set up to track 'origin/gh-pages'.
time="2024-04-29T15:00:42Z" level=info msg="Template file: /home/runner/work/helm-charts/helm-charts/index.tpl"
time="2024-04-29T15:00:42Z" level=info msg="Reading /home/runner/work/helm-charts/helm-charts/index.yaml"
time="2024-04-29T15:00:42Z" level=info msg="Processing yaml"
time="2024-04-29T15:00:42Z" level=info msg="Creating /home/runner/work/helm-charts/helm-charts/index.html"
time="2024-04-29T15:00:42Z" level=info msg="Outputting template /home/runner/work/helm-charts/helm-charts/index.html"
[gh-pages 2d0f652] Update index.html
 1 file changed, 3 insertions(+), 3 deletions(-)
To https://github.com/accelleran/helm-charts
 ! [rejected]        gh-pages -> gh-pages (non-fast-forward)
error: failed to push some refs to 'https://github.com/accelleran/helm-charts'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

In this run, there were two back-to-back releases (drax 7.2.0-rc.0 and cucp-7.1.0). On the second release (cucp) the commit to add the drax release to `index.yaml` was visible, but the one of the cucp not. Because there was a diff with drax, the `index.html` file got updated, but because the addition of the cucp release in the `index.yaml` was not yet known, the `index.html` file commit was rejected when trying to push.