### PR TITLE
fix: use fixed app version

### DIFF
--- a/charts/du-metrics-server/Chart.yaml
+++ b/charts/du-metrics-server/Chart.yaml
@@ -3,6 +3,7 @@ name: du-metrics-server
 description: Accelleran's DU metrics server
 type: application
 version: 0.1.0
+# renovate: image=accelleran/du-metrics-server versioning=semver
 appVersion: 1.0.0
 dependencies:
   - name: common

--- a/charts/du-metrics-server/Chart.yaml
+++ b/charts/du-metrics-server/Chart.yaml
@@ -3,7 +3,7 @@ name: du-metrics-server
 description: Accelleran's DU metrics server
 type: application
 version: 0.1.0
-appVersion: "edge"
+appVersion: 1.0.0
 dependencies:
   - name: common
     version: 0.2.2


### PR DESCRIPTION
Until now the `master` branch builds of the DU metrics server were in use, instead of a proper release. This PR fixes that.