### PR TITLE
fix: fix extraEnvs

### DIFF
--- a/charts/common/templates/_container.tpl
+++ b/charts/common/templates/_container.tpl
@@ -9,7 +9,7 @@
 
 {{- $env := get . "env" | default list -}}
 {{- with $values.extraEnvs -}}
-{{- $env = append $env . -}}
+{{- $env = concat $env . -}}
 {{- end -}}
 
 {{- $envFrom := get . "envFrom" | default list -}}


### PR DESCRIPTION
Before this fix, the list of extraEnvs was appended as a single item with a list inside.