### PR TITLE
feat: add config to publish DU metrics on kafka

### DIFF
--- a/charts/du-metrics-server/templates/configmap-bootstrap.yaml
+++ b/charts/du-metrics-server/templates/configmap-bootstrap.yaml
@@ -1,0 +1,6 @@
+{{- if index $.Values "du-metrics-server" "config" "kafkaPublishingEnabled" -}}
+{{- include
+      "accelleran.common.bootstrap.configMap"
+      (dict "top" $)
+-}}
+{{- end -}}

--- a/charts/du-metrics-server/templates/deployment.yaml
+++ b/charts/du-metrics-server/templates/deployment.yaml
@@ -7,6 +7,7 @@
 {{- $ := . -}}
 {{- $values := index $.Values "du-metrics-server" -}}
 {{- $fullname := include "accelleran.common.fullname" (dict "top" $ "values" $values) -}}
+{{- $bootstrapConfigMapName := get . "bootstrapConfigMapName" | default (include "accelleran.common.bootstrap.configMapName" (dict "top" $ "values" $values))  -}}
 
 top:
   {{ $ | toYaml | nindent 2 }}
@@ -32,4 +33,20 @@ env:
       secretKeyRef:
         name: {{ (($.Values.influxdb).adminUser).existingSecret | default (printf "%s-auth" (($.Values.influxdb).fullnameOverride | default (printf "%s-%s" $.Release.Name (($.Values.influxdb).nameOverride | default "influxdb")))) }}
         key: admin-token
+{{- if $values.config.kafkaPublishingEnabled }}
+  - name: KAFKA_HOSTNAME
+    valueFrom:
+      configMapKeyRef:
+        name: {{ $bootstrapConfigMapName | quote }}
+        key: KAFKA_HOSTNAME
+  - name: KAFKA_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: {{ $bootstrapConfigMapName | quote }}
+        key: KAFKA_PORT
+{{- with $values.config.topic }}
+  - name: TOPIC
+    value: {{ . | quote }}
+{{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/du-metrics-server/values.yaml
+++ b/charts/du-metrics-server/values.yaml
@@ -1,6 +1,16 @@
+bootstrap:
+  create: true
+  name: ""
+  kafka:
+    enabled: true
+    hostname: ""
+    port: 0
+
 du-metrics-server:
   config:
     testbed: default
+    kafkaPublishingEnabled: false
+    topic: default_topic
 
   replicaCount: 1
 


### PR DESCRIPTION
This PR adds the config to also allow publishing DU metrics to kafka.

There is an option to enable or disable the kafka publishing, which will be disabled by default as there is no kafka server included in the du-metrics-server chart. In the drax chart it will be enabled by default though as we setup kafka there.

Before merging:
* [x] This will first need a `1.0.2` release of docker image `accelleran/du-metrics-server` before it can be merged (will be done automatically by renovate).
* [x] The commits including config in the drax values file should be added in a separate PR together with (or after) the du-metrics-server helm chart version bump in the drax `Chart.yaml` file. So this PR can't be merged as is yet, but it gives the full picture of what it should end up looking like.