### PR TITLE
ci: use team reviews for renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,7 @@
   "dependencyDashboardApproval": false,
   "dependencyDashboardAutoclose": false,
   "reviewers": [
-    "ben-foxmoore",
-    "Wielewout"
+    "team:dRAX"
   ],
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [


### PR DESCRIPTION
Note that the organization shouldn't be mentioned as part of the team name: https://docs.renovatebot.com/configuration-options/#reviewers