### PR TITLE
feat: enable kafka publishing for du-metrics-server

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -143,6 +143,11 @@ du-metrics-server:
     create: false
     name: "{{ $.Release.Name }}-bootstrap"
 
+  du-metrics-server:
+    config:
+      kafkaPublishingEnabled: true
+      topic: accelleran.drax.5g.du.metrics
+
   influxdb:
     nameOverride: "du-influxdb"
 

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -139,6 +139,10 @@ cell-wrapper:
 du-metrics-server:
   enabled: true
 
+  bootstrap:
+    create: false
+    name: "{{ $.Release.Name }}-bootstrap"
+
   influxdb:
     nameOverride: "du-influxdb"
 


### PR DESCRIPTION
Continuation of https://github.com/accelleran/helm-charts/pull/224.

The changes have been approved there already, but they need to be merged in separately.

Again there are a couple of things that need to happen before merging (in the presented order!):
* [x] Merge kafka config additions (merge #224)
* [x] Create du-metrics-server chart release (merge #216)
* [x] Bump du-metrics-server chart version in the drax chart (merge #232, will be done automatically by renovate)