### PR TITLE
fix(deps): update e2 to 5.2.15

### DIFF
--- a/charts/drax/charts/e2-t/Chart.yaml
+++ b/charts/drax/charts/e2-t/Chart.yaml
@@ -3,7 +3,7 @@ name: e2-t
 description: The E2 Termination
 type: application
 version: 1.1.0
-appVersion: "e2-5.2.14"
+appVersion: "e2-5.2.15"
 dependencies:
   - name: common
     version: 0.2.3


### PR DESCRIPTION
We'll need to wait until the next release of the e2 docker images before we can let renovate handle this.