### PR TITLE
fix(deps)!: update cucp to 5.0.6

### DIFF
--- a/charts/cu-cp/Chart.yaml
+++ b/charts/cu-cp/Chart.yaml
@@ -4,7 +4,7 @@ description: Accelleran 5G CU-CP Components
 type: application
 version: 7.1.0
 # renovate: image=accelleran/cucp-netconf
-appVersion: "R4.3.16_leffe"
+appVersion: "5.0.6"
 dependencies:
   - name: common
     version: 0.2.3


### PR DESCRIPTION
From now on the updates should also be handled by renovate as the tag can be properly recognized.