### PR TITLE
fix(deps)!: update cuup to 5.0.6

### DIFF
--- a/charts/cu-up/Chart.yaml
+++ b/charts/cu-up/Chart.yaml
@@ -4,7 +4,7 @@ description: Accelleran 5G CU-UP Components
 type: application
 version: 7.1.0
 # renovate: image=accelleran/cuup-netconf
-appVersion: "R4.3.16_leffe"
+appVersion: "5.0.6"
 dependencies:
   - name: common
     version: 0.2.3


### PR DESCRIPTION
From now on the updates should also be handled by renovate as the tag can be properly recognized.