### PR TITLE
fix(deps)!: update cw to 4.0.0

### DIFF
--- a/charts/cell-wrapper/Chart.yaml
+++ b/charts/cell-wrapper/Chart.yaml
@@ -3,8 +3,8 @@ name: cell-wrapper
 description: Accelleran's cell-wrapper helm chart
 type: application
 version: 3.1.0
-# renovate: image=accelleran/cw-netconf versioning=loose extract_version=^CW(?<version>.*)$
-appVersion: "CW3.1.0"
+# renovate: image=accelleran/cw-netconf versioning=semver
+appVersion: "4.0.0"
 dependencies:
   - name: common
     version: 0.3.0


### PR DESCRIPTION
Currently this release doesn't exist yet as it's still in the release candidate stage. This is a breaking change as the release tag scheme changed to a proper semantic version without the `CW` prefix.

After this is merged renovate should pickup updates automatically.