### PR TITLE
fix!: switch to image values that renovate automatically updates

### DIFF
--- a/charts/common/templates/_init.tpl
+++ b/charts/common/templates/_init.tpl
@@ -56,7 +56,7 @@ Init container check waiting until redis is available
 {{- $values := get . "values" | default $.Values -}}
 
 {{- $bootstrapConfigMapName :=  get . "bootstrapConfigMapName" | default (include "accelleran.common.bootstrap.configMapName" .) -}}
-{{- $image := ($values.initImage).redis | required "The redis init image needs to be provided to common init redis args" -}}
+{{- $image := $values.redisInitImage | required "The redis init image needs to be provided to common init redis args" -}}
 
 top:
   {{ $ | toYaml | nindent 2 }}
@@ -108,7 +108,7 @@ Init container check waiting until NATS is available
 {{- $values := get . "values" | default $.Values -}}
 
 {{- $bootstrapConfigMapName := get . "bootstrapConfigMapName" | default (include "accelleran.common.bootstrap.configMapName" .)  -}}
-{{- $image := ($values.initImage).nats | required "The nats init image needs to be provided to common init nats args" -}}
+{{- $image := $values.natsInitImage | required "The nats init image needs to be provided to common init nats args" -}}
 
 top:
   {{ $ | toYaml | nindent 2 }}
@@ -161,7 +161,7 @@ Init container check waiting until kafka is available
 {{- $values := get . "values" | default $.Values -}}
 
 {{- $bootstrapConfigMapName := get . "bootstrapConfigMapName" | default (include "accelleran.common.bootstrap.configMapName" .)  -}}
-{{- $image := ($values.initImage).kafka | required "The kafka init image needs to be provided to common init kafka args" -}}
+{{- $image := $values.kafkaInitImage | required "The kafka init image needs to be provided to common init kafka args" -}}
 
 top:
   {{ $ | toYaml | nindent 2 }}


### PR DESCRIPTION
Renovate expects a structure like:

```yaml
image:
  repository: "<docker-repo>"
  tag: "<tag>"
```

Here the image could be replaced with anything that also contains `image` or `Image`,
which wasn't the case with the structure we had up until now as there was one more level of nesting:

```yaml
initImage:
  redis:
    repository: "<docker-repo>"
    tag: "<tag>"
```

The following PRs are a follow up on this one:
* [ ] #247
* [ ] #248
* [ ] #249
* [ ] #250
* [ ] #251
* [ ] #252

Note that after the chart common 0.3.0 is released, a PR by renovate will be created. This one will automatically fail the tests in the CI and should be closed then in favor of the above PRs. These are separated per chart so they can be merged separately when a breaking change is appropriate.