### PR TITLE
fix(deps)!: update drax to common chart 0.3.0

### DIFF
--- a/charts/drax/Chart.lock
+++ b/charts/drax/Chart.lock
@@ -1,22 +1,22 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
+  version: 0.3.0
 - name: dashboard
   repository: file://charts/dashboard
-  version: 5.0.0
+  version: 6.0.0
 - name: network-state-monitor
   repository: file://charts/network-state-monitor
-  version: 0.1.1
+  version: 0.2.0
 - name: service-monitor
   repository: file://charts/service-monitor
-  version: 1.0.0
+  version: 2.0.0
 - name: service-orchestrator
   repository: file://charts/service-orchestrator
-  version: 1.1.1
+  version: 2.0.0
 - name: config-api
   repository: file://charts/config-api
-  version: 2.0.0
+  version: 3.0.0
 - name: cell-wrapper
   repository: https://accelleran.github.io/helm-charts/
   version: 4.0.0
@@ -28,10 +28,10 @@ dependencies:
   version: 2.0.0
 - name: pm-counters
   repository: file://charts/pm-counters
-  version: 1.1.0
+  version: 2.0.0
 - name: golang-nkafka
   repository: file://charts/golang-nkafka
-  version: 1.2.2
+  version: 2.0.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 8.0.0
@@ -59,5 +59,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
   version: 19.5.2
-digest: sha256:fa16a85d5b0dc764933c6169147d0f08832be5f7ca7d64e3b7c76e1c41bf85d2
-generated: "2024-06-07T10:40:17.026716659Z"
+digest: sha256:30284020909aa184dc82fd191577defce2911f0892d1f57db4ae30cf4f72fef7
+generated: "2024-06-07T12:45:40.658582067+02:00"

--- a/charts/drax/Chart.lock
+++ b/charts/drax/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 2.0.0
 - name: cell-wrapper
   repository: https://accelleran.github.io/helm-charts/
-  version: 3.1.0
+  version: 4.0.0
 - name: du-metrics-server
   repository: https://accelleran.github.io/helm-charts/
   version: 0.2.1
@@ -59,5 +59,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
   version: 19.5.2
-digest: sha256:60f27156d0099dc5f492a49aef75c6629c4cde993dd21775db67f55a14b43d67
-generated: "2024-06-06T18:34:47.00323935Z"
+digest: sha256:fa16a85d5b0dc764933c6169147d0f08832be5f7ca7d64e3b7c76e1c41bf85d2
+generated: "2024-06-07T10:40:17.026716659Z"

--- a/charts/drax/Chart.yaml
+++ b/charts/drax/Chart.yaml
@@ -5,29 +5,29 @@ type: application
 version: 7.2.0-rc.2
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/
 
   # smo
   - name: dashboard
     condition: dashboard.enabled
-    version: 5.0.0
+    version: 6.0.0
     repository: file://charts/dashboard
   - name: network-state-monitor
     condition: network-state-monitor.enabled
-    version: 0.1.1
+    version: 0.2.0
     repository: file://charts/network-state-monitor
   - name: service-monitor
     condition: service-monitor.enabled
-    version: 1.0.0
+    version: 2.0.0
     repository: file://charts/service-monitor
   - name: service-orchestrator
     condition: service-orchestrator.enabled
-    version: 1.1.1
+    version: 2.0.0
     repository: file://charts/service-orchestrator
   - name: config-api
     condition: config-api.enabled
-    version: 2.0.0
+    version: 3.0.0
     repository: file://charts/config-api
   - name: cell-wrapper
     condition: cell-wrapper.enabled
@@ -47,14 +47,14 @@ dependencies:
   # xapps
   - name: pm-counters
     condition: pm-counters.enabled
-    version: 1.1.0
+    version: 2.0.0
     repository: file://charts/pm-counters
 
   # infrastructure
   - name: golang-nkafka
     alias: golang-nkafka-5g
     condition: global.enable5G
-    version: 1.2.2
+    version: 2.0.0
     repository: file://charts/golang-nkafka
 
   # external

--- a/charts/drax/Chart.yaml
+++ b/charts/drax/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     repository: file://charts/config-api
   - name: cell-wrapper
     condition: cell-wrapper.enabled
-    version: 3.1.0
+    version: 4.0.0
     repository: https://accelleran.github.io/helm-charts/
   - name: du-metrics-server
     condition: du-metrics-server.enabled

--- a/charts/drax/charts/config-api/Chart.yaml
+++ b/charts/drax/charts/config-api/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: config-api
 description: Backend of the Accelleran Dashboard
 type: application
-version: 2.0.0
+version: 3.0.0
 # renovate: image=accelleran/config-api
 appVersion: 1.3.1
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/dashboard/Chart.yaml
+++ b/charts/drax/charts/dashboard/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: dashboard
 description: The Accelleran Dashboard
 type: application
-version: 5.0.0
+version: 6.0.0
 # renovate: image=accelleran/dash-front-back-end
 appVersion: 5.3.0
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/dashboard/values.yaml
+++ b/charts/drax/charts/dashboard/values.yaml
@@ -51,11 +51,10 @@ replicaCount: 1
 nameOverride: ""
 fullnameOverride: ""
 
-initImage:
-  kafka:
-    repository: accelleran/acc-generic-img
-    pullPolicy: IfNotPresent
-    tag: "0.8.0"
+kafkaInitImage:
+  repository: accelleran/acc-generic-img
+  pullPolicy: IfNotPresent
+  tag: "0.8.0"
 
 image:
   repository: accelleran/dash-front-back-end

--- a/charts/drax/charts/e2-t/Chart.yaml
+++ b/charts/drax/charts/e2-t/Chart.yaml
@@ -6,7 +6,7 @@ version: 2.0.0
 appVersion: "e2-5.2.15"
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/
   - name: nats
     condition: nats.enabled

--- a/charts/drax/charts/e2-t/values.yaml
+++ b/charts/drax/charts/e2-t/values.yaml
@@ -47,15 +47,15 @@ drax:
 nameOverride: ""
 fullnameOverride: ""
 
-initImage:
-  redis:
-    repository: accelleran/acc-generic-img
-    tag: "0.8.0"
-    pullPolicy: IfNotPresent
-  nats:
-    repository: accelleran/acc-generic-img
-    tag: "0.8.0"
-    pullPolicy: IfNotPresent
+redisInitImage:
+  repository: accelleran/acc-generic-img
+  tag: "0.8.0"
+  pullPolicy: IfNotPresent
+
+natsInitImage:
+  repository: accelleran/acc-generic-img
+  tag: "0.8.0"
+  pullPolicy: IfNotPresent
 
 accelleranLicense:
   enabled: false

--- a/charts/drax/charts/golang-nkafka/Chart.yaml
+++ b/charts/drax/charts/golang-nkafka/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: golang-nkafka
 description: The Accelleran dRAX nats-kafka bridge
 type: application
-version: 1.2.2
+version: 2.0.0
 appVersion: 1.3.5
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/golang-nkafka/values.yaml
+++ b/charts/drax/charts/golang-nkafka/values.yaml
@@ -46,15 +46,15 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-initImage:
-  nats:
-    repository: accelleran/acc-generic-img
-    pullPolicy: IfNotPresent
-    tag: "0.8.0"
-  kafka:
-    repository: accelleran/acc-generic-img
-    pullPolicy: IfNotPresent
-    tag: "0.8.0"
+natsInitImage:
+  repository: accelleran/acc-generic-img
+  pullPolicy: IfNotPresent
+  tag: "0.8.0"
+
+kafkaInitImage:
+  repository: accelleran/acc-generic-img
+  pullPolicy: IfNotPresent
+  tag: "0.8.0"
 
 image:
   repository: accelleran/golang-nkafka-5g

--- a/charts/drax/charts/network-state-monitor/Chart.yaml
+++ b/charts/drax/charts/network-state-monitor/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: network-state-monitor
 description: The Accelleran dRAX Network State Monitor
 type: application
-version: 0.1.1
+version: 0.2.0
 # renovate: image=accelleran/network-state-monitor
 appVersion: 1.2.0
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/network-state-monitor/values.yaml
+++ b/charts/drax/charts/network-state-monitor/values.yaml
@@ -37,11 +37,10 @@ imagePullSecrets:
 accelleranLicense:
   enabled: false
 
-initImage:
-  kafka:
-    repository: accelleran/acc-generic-img
-    pullPolicy: IfNotPresent
-    tag: "0.8.0"
+kafkaInitImage:
+  repository: accelleran/acc-generic-img
+  pullPolicy: IfNotPresent
+  tag: "0.8.0"
 
 podSecurityContext:
   {}

--- a/charts/drax/charts/pm-counters/Chart.yaml
+++ b/charts/drax/charts/pm-counters/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: pm-counters
 description: The Accelleran dRAX PM Counters xAPP
 type: application
-version: 1.1.0
+version: 2.0.0
 # renovate: image=accelleran/acc-fiveg-pmcounters
 appVersion: 1.1.0
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/pm-counters/values.yaml
+++ b/charts/drax/charts/pm-counters/values.yaml
@@ -27,11 +27,10 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-initImage:
-  kafka:
-    repository: accelleran/acc-generic-img
-    pullPolicy: IfNotPresent
-    tag: "0.8.0"
+kafkaInitImage:
+  repository: accelleran/acc-generic-img
+  pullPolicy: IfNotPresent
+  tag: "0.8.0"
 
 image:
   repository: accelleran/acc-fiveg-pmcounters

--- a/charts/drax/charts/service-monitor/Chart.yaml
+++ b/charts/drax/charts/service-monitor/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: service-monitor
 description: The Accelleran dRAX Service Monitor
 type: application
-version: 1.0.0
+version: 2.0.0
 # renovate: image=accelleran/service-monitor
 appVersion: 1.0.1
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/service-orchestrator/Chart.yaml
+++ b/charts/drax/charts/service-orchestrator/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: service-orchestrator
 description: The dRAX Service Orchestrator
 type: application
-version: 1.1.1
+version: 2.0.0
 # renovate: image=accelleran/service-orchestrator
 appVersion: 1.1.0
 dependencies:
   - name: common
-    version: 0.2.3
+    version: 0.3.0
     repository: https://accelleran.github.io/helm-charts/

--- a/charts/drax/charts/service-orchestrator/values.yaml
+++ b/charts/drax/charts/service-orchestrator/values.yaml
@@ -26,6 +26,7 @@ replicaCount: 1
 image:
   repository: accelleran/service-orchestrator
   pullPolicy: IfNotPresent
+  tag: ""
 
 imagePullSecrets:
   - name: accelleran-secret


### PR DESCRIPTION
* [x] #246 needs to be merged first
* [x] cell-wrapper 4.0.0 chart release dependency updated; (this apperently needs to happen together with the common 0.3.0 update as there are failures)
* [x] du-metrics-server 0.2.0 chart release dependency updated
* [x] merge #257 first as it would bump the subchart version (otherwise there would be another version bump on top of the breaking change here); this is superseded by #288
* [x] Update versions of the subcharts to indicate them as breaking
* [x] `helm dependency update` to update `Chart.lock`

BEGIN_COMMIT_OVERRIDE
fix(deps)!: update helm release cell-wrapper to v4
fix(deps)!: update drax to common chart 0.3.0
END_COMMIT_OVERRIDE