### PR TITLE
fix(deps): update helm release loki-stack to v2.10.2

### DIFF
--- a/charts/drax/Chart.lock
+++ b/charts/drax/Chart.lock
@@ -40,7 +40,7 @@ dependencies:
   version: 25.21.0
 - name: loki-stack
   repository: https://grafana.github.io/helm-charts
-  version: 2.10.1
+  version: 2.10.2
 - name: influxdb
   repository: https://helm.influxdata.com/
   version: 4.12.5
@@ -59,5 +59,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
   version: 19.5.0
-digest: sha256:d5d62d039b6871637750dedb297e4b81d18e7e5455ecb6788820a842422ed71e
-generated: "2024-06-03T11:59:11.680544278Z"
+digest: sha256:33a955ec3f024ec7c5e539d38acfc01182898e51f9f2f738a6a326dca669f449
+generated: "2024-06-03T15:27:26.917644147+02:00"

--- a/charts/drax/Chart.yaml
+++ b/charts/drax/Chart.yaml
@@ -71,7 +71,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
   - name: loki-stack
     condition: loki-stack.enabled
-    version: 2.10.1
+    version: 2.10.2
     repository: https://grafana.github.io/helm-charts
   - name: influxdb
     condition: influxdb.enabled


### PR DESCRIPTION
Update to latest loki-stack. Even though it doesn't impact anything we actively use, it's better to stick to the latest for clarity. I was confused for a bit why we weren't on the latest until I saw that #154 was closed. Unfortunately I couldn't reopen that PR, hence this one...