### PR TITLE
fix!: use different topics for DU metrics

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -146,7 +146,11 @@ du-metrics-server:
   du-metrics-server:
     config:
       kafkaPublishingEnabled: true
-      topic: accelleran.drax.5g.du.metrics
+      topics:
+        default: accelleran.drax.5g.du_metrics
+        ue_kpis: accelleran.drax.5g.du_metrics.ue_mac
+        rlc_tx_kpis: accelleran.drax.5g.du_metrics.ue_rlc_tx
+        rlc_rx_kpis: accelleran.drax.5g.du_metrics.ue_rlc_rx
 
   influxdb:
     nameOverride: "du-influxdb"


### PR DESCRIPTION
Specify for the different messages a different topic. Also the prefix changed to `accelleran.drax.5g.du_metrics`.

Before merge:
* [x] #270 needs to be part of new du-metrics-server release