### PR TITLE
feat: increase max entries limit per query to 10000 in loki

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -670,6 +670,8 @@ loki-stack:
         retention_deletes_enabled: true
         # Must be a multiple of 168h
         retention_period: 672h
+      limits_config:
+        max_entries_limit_per_query: 10000
 
 
 influxdb:


### PR DESCRIPTION
Increased to 10000 as this was the original value that was played with. I don't know what would be the most sensible one for us? With this inclusion we at least know already how to configure it, it's easy to change the value at a later point if needed.