### PR TITLE
fix: increase kafka resource preset

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -254,12 +254,14 @@ kafka:
     nodeSelector: {}
     persistence:
       size: 1Gi
+    resourcesPreset: medium
 
   broker:
     automountServiceAccountToken: true
     nodeSelector: {}
     persistence:
       size: 1Gi
+    resourcesPreset: medium
 
   provisioning:
     enabled: true


### PR DESCRIPTION
The default `small` sometimes results in `OOMKilled` during initialization. Therefore we increase it to `medium` to have more memory available (the memory is doubled compared to `small`, the rest of the resources remains the same).

More info on the sizes: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15