### PR TITLE
ci: add renovate updates for major dev env version in svc orch config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,13 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
     },
     {
+      "datasourceTemplate": "helm",
+      "fileMatch": ["(^|/)values\\.y[a]?ml$"],
+      "matchStrings": [
+        "#\\s?renovate: repository=(?<registryUrl>.*?) chart=(?<depName>.*?)\\s?[\\w\\-]*[vV]ersion:\\s?\"?(?<currentValue>[\\w\\.\\-]*)\"?"
+      ]
+    },
+    {
       "datasourceTemplate": "github-releases",
       "fileMatch": ["(^|/)helm-charts\\.y[a]?ml$"],
       "matchStrings": [

--- a/charts/drax/charts/service-orchestrator/values.yaml
+++ b/charts/drax/charts/service-orchestrator/values.yaml
@@ -2,6 +2,7 @@ global: {}
 
 kubeIp: "10.55.1.2"
 default5gVersion: "6"
+# renovate: repository=https://accelleran.github.io/helm-charts chart=xapp-hello-world
 defaultDevEnvVersion: "2"
 
 config:


### PR DESCRIPTION
As helm versioning in renovate supports ranges, I'm expecting this to work.
I couldn't find a similar example though to really confirm this behavior...