### PR TITLE
style: fix linter issues in xapp-redis

### DIFF
--- a/charts/xapp-hello-world/charts/xapp-redis/values.yaml
+++ b/charts/xapp-hello-world/charts/xapp-redis/values.yaml
@@ -25,10 +25,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext: 
+podSecurityContext:
   fsGroup: 0
 
-securityContext: 
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
@@ -38,7 +38,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  #nodePort: 31802
+  # nodePort: 31802
   port: 6379
   name: "xapp-redis"
 


### PR DESCRIPTION
There is an issue in the CI where during a run on a PR the linter only looks at charts in the root level (and thus not within subcharts, like xapp-redis here). In this PR the lint issues are resolved in that chart, but we should have a look at fixing the CI for PRs later then.