### PR TITLE
fix(deps): revert bitnami helm charts to oldest known release

### DIFF
--- a/charts/cell-wrapper/Chart.lock
+++ b/charts/cell-wrapper/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.1.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
-  version: 19.5.2
-digest: sha256:27f860eaceb86eece3ecf3f5670e5d57b0e98f3f0dd8a4f6d04e5763b1ed2f56
-generated: "2024-06-06T18:36:10.758101142Z"
+  version: 19.5.0
+digest: sha256:31d79a6ed6d3a890f363e41cfebc85edf8afadb3b7141bdc111a9d2ea2b97f48
+generated: "2024-06-07T11:35:36.240948812+02:00"

--- a/charts/cell-wrapper/Chart.yaml
+++ b/charts/cell-wrapper/Chart.yaml
@@ -15,5 +15,5 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: redis
     condition: redis.enabled
-    version: 19.5.2
+    version: 19.5.0
     repository: https://charts.bitnami.com/bitnami/

--- a/charts/cu-cp/Chart.lock
+++ b/charts/cu-cp/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.1.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
-  version: 19.5.2
-digest: sha256:27f860eaceb86eece3ecf3f5670e5d57b0e98f3f0dd8a4f6d04e5763b1ed2f56
-generated: "2024-06-06T18:35:51.066532381Z"
+  version: 19.5.0
+digest: sha256:31d79a6ed6d3a890f363e41cfebc85edf8afadb3b7141bdc111a9d2ea2b97f48
+generated: "2024-06-07T11:36:26.297639991+02:00"

--- a/charts/cu-cp/Chart.yaml
+++ b/charts/cu-cp/Chart.yaml
@@ -15,5 +15,5 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: redis
     condition: redis.enabled
-    version: 19.5.2
+    version: 19.5.0
     repository: https://charts.bitnami.com/bitnami/

--- a/charts/cu-up/Chart.lock
+++ b/charts/cu-up/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.1.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
-  version: 19.5.2
-digest: sha256:27f860eaceb86eece3ecf3f5670e5d57b0e98f3f0dd8a4f6d04e5763b1ed2f56
-generated: "2024-06-06T18:35:31.496470281Z"
+  version: 19.5.0
+digest: sha256:31d79a6ed6d3a890f363e41cfebc85edf8afadb3b7141bdc111a9d2ea2b97f48
+generated: "2024-06-07T11:36:59.309826546+02:00"

--- a/charts/cu-up/Chart.yaml
+++ b/charts/cu-up/Chart.yaml
@@ -15,5 +15,5 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: redis
     condition: redis.enabled
-    version: 19.5.2
+    version: 19.5.0
     repository: https://charts.bitnami.com/bitnami/

--- a/charts/drax/Chart.lock
+++ b/charts/drax/Chart.lock
@@ -52,12 +52,12 @@ dependencies:
   version: 0.13.0
 - name: kafka
   repository: https://charts.bitnami.com/bitnami/
-  version: 29.2.4
+  version: 29.2.2
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.1.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
-  version: 19.5.2
-digest: sha256:60f27156d0099dc5f492a49aef75c6629c4cde993dd21775db67f55a14b43d67
-generated: "2024-06-06T18:34:47.00323935Z"
+  version: 19.5.0
+digest: sha256:19af65994969a3245b327196a4454f10c8d56cfda9d5c2e4b3d5f6bca83dafc3
+generated: "2024-06-07T11:39:41.309409782+02:00"

--- a/charts/drax/Chart.yaml
+++ b/charts/drax/Chart.yaml
@@ -88,7 +88,7 @@ dependencies:
   # infrastructure
   - name: kafka
     condition: kafka.enabled
-    version: 29.2.4
+    version: 29.2.2
     repository: https://charts.bitnami.com/bitnami/
   - name: nats
     condition: nats.enabled
@@ -96,5 +96,5 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: redis
     condition: redis.enabled
-    version: 19.5.2
+    version: 19.5.0
     repository: https://charts.bitnami.com/bitnami/

--- a/charts/drax/charts/e2-t/Chart.lock
+++ b/charts/drax/charts/e2-t/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.1.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
-  version: 19.5.2
-digest: sha256:415ebe98bffc272f89dfa29562bc4d665775669dfb76b3e34bf2f99115f5020f
-generated: "2024-06-06T18:34:24.772114186Z"
+  version: 19.5.0
+digest: sha256:7a7c50a87aaae4225849025a9612dd90c82252e3483532ce5ae059aab34f2343
+generated: "2024-06-07T11:37:50.454100391+02:00"

--- a/charts/drax/charts/e2-t/Chart.yaml
+++ b/charts/drax/charts/e2-t/Chart.yaml
@@ -14,5 +14,5 @@ dependencies:
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: redis
     condition: redis.enabled
-    version: 19.5.2
+    version: 19.5.0
     repository: https://charts.bitnami.com/bitnami/


### PR DESCRIPTION
This reverts redis back to 19.5.0
This reverts kafka back to 29.2.2

Bitnami's helm server lost a couple of version of some charts for some reason. Reverting until resolved as it breaks the CI and thus blocks a release...