### PR TITLE
fix: fix Chart.lock files of drax subcharts

### DIFF
--- a/charts/drax/charts/config-api/Chart.lock
+++ b/charts/drax/charts/config-api/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:59:00.684576909Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:02:40.762347349+02:00"

--- a/charts/drax/charts/dashboard/Chart.lock
+++ b/charts/drax/charts/dashboard/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:58:52.862653459Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:05:00.778300364+02:00"

--- a/charts/drax/charts/e2-t/Chart.lock
+++ b/charts/drax/charts/e2-t/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
+  version: 0.3.0
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.1.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami/
   version: 19.5.2
-digest: sha256:415ebe98bffc272f89dfa29562bc4d665775669dfb76b3e34bf2f99115f5020f
-generated: "2024-06-06T18:34:24.772114186Z"
+digest: sha256:27f860eaceb86eece3ecf3f5670e5d57b0e98f3f0dd8a4f6d04e5763b1ed2f56
+generated: "2024-06-07T13:05:25.08820339+02:00"

--- a/charts/drax/charts/golang-nkafka/Chart.lock
+++ b/charts/drax/charts/golang-nkafka/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:58:31.438890537Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:05:41.121793287+02:00"

--- a/charts/drax/charts/network-state-monitor/Chart.lock
+++ b/charts/drax/charts/network-state-monitor/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:58:26.39008718Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:06:13.469461067+02:00"

--- a/charts/drax/charts/pm-counters/Chart.lock
+++ b/charts/drax/charts/pm-counters/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:58:21.207312153Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:06:29.46917324+02:00"

--- a/charts/drax/charts/service-monitor/Chart.lock
+++ b/charts/drax/charts/service-monitor/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:58:16.136026464Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:06:41.504551706+02:00"

--- a/charts/drax/charts/service-orchestrator/Chart.lock
+++ b/charts/drax/charts/service-orchestrator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://accelleran.github.io/helm-charts/
-  version: 0.2.3
-digest: sha256:62963b97b0ed4827b377696c1b068eefd50c9bba8c1855f5891a1eb56b69aa51
-generated: "2024-05-22T08:58:10.832950827Z"
+  version: 0.3.0
+digest: sha256:993a52045cf11e7a183de418e22ad6c22fa8139cf53cfcfbdc7e7d0490365105
+generated: "2024-06-07T13:06:57.560583976+02:00"


### PR DESCRIPTION
Fixes the forgotten Chart.lock file updates in the drax subcharts in #252 