### PR TITLE
ci: fix ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -20,7 +20,7 @@ jobs:
 
   lint-commits:
     name: Lint Commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Variables
     # This is a work-around to be able to properly use variables.
     # This job should be made a dependency in order to be able to use its outputs.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       is_main_branch: ${{ github.ref_type == 'branch' && github.ref_name == 'main' }}
       is_release_branch: ${{ github.ref_type == 'branch' && startsWith(github.ref_name, 'releases/') }}
@@ -54,7 +54,7 @@ jobs:
     name: Lint Charts
     needs:
       - vars
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -118,7 +118,7 @@ jobs:
     name: Test Charts
     needs:
       - vars
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -250,7 +250,7 @@ jobs:
       - vars
       - lint-charts
       - test-charts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-please-pr-labels.yaml
+++ b/.github/workflows/release-please-pr-labels.yaml
@@ -10,7 +10,7 @@ jobs:
   label-release-pr:
     name: Label Release PR
     if: "${{ startsWith(github.event.pull_request.title, 'chore: release') }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Release please
         if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'releases/') }}


### PR DESCRIPTION
This PR fixes the ubuntu runner versions to 22.04 so we can upgrade to 24.04 in a controlled way. Normally github would indicate this clearly with some time to prepare for the upgrade. But it would still be better to control this explicitly and let renovate handle the upgrade.