### PR TITLE
ci: fix metallb subnet potentially being an ipv6 subnet

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -174,9 +174,15 @@ jobs:
             --selector=app=metallb \
             --timeout=90s
 
-          subnet=$(docker network inspect -f '{{range .IPAM.Config}}{{printf "%s\n" .Subnet}}{{end}}' kind | head -n 1)
+          subnets=$(docker network inspect -f '{{range .IPAM.Config}}{{printf "%s\n" .Subnet}}{{end}}' kind)
+          printf "subnets:\n%s\n" "${subnets}"
+          subnet=$(echo "$subnets" | head -n 1)
+          printf "subnet: '%s'\n" "${subnet}"
+
           net_ip=$(echo "$subnet" | cut -d/ -f1)
+          printf "net_ip: '%s'\n" "${net_ip}"
           cidr=$(echo "$subnet" | cut -d/ -f2)
+          printf "cidr: '%s'\n" "${cidr}"
           if [ $cidr -gt 24 ]; then
             echo "CIDR of $subnet needs to be 24 or smaller" 1>&2
             exit 1
@@ -184,6 +190,7 @@ jobs:
 
           net_ip_prefix=$(echo $net_ip | cut -d. -f 1-3)
           ip_range=$net_ip_prefix.200-$net_ip_prefix.250
+          printf "ip_range: '%s'\n" "${ip_range}"
 
           cat <<EOF | kubectl apply -f -
           apiVersion: metallb.io/v1beta1

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -176,7 +176,9 @@ jobs:
 
           subnets=$(docker network inspect -f '{{range .IPAM.Config}}{{printf "%s\n" .Subnet}}{{end}}' kind)
           printf "subnets:\n%s\n" "${subnets}"
-          subnet=$(echo "$subnets" | head -n 1)
+          ipv4_subnets=$(echo "$subnets" | grep -E '(([0-9]{1,3})\.){3}([0-9]{1,3})\/([0-9]|[1-2][0-9]|3[0-2])')
+          printf "ipv4_subnets:\n%s\n" "${ipv4_subnets}"
+          subnet=$(echo "$ipv4_subnets" | head -n 1)
           printf "subnet: '%s'\n" "${subnet}"
 
           net_ip=$(echo "$subnet" | cut -d/ -f1)


### PR DESCRIPTION
This PR adds an additional filter for ipv4 subnets (with grep and regex) so that the (wrong) assumption of always having ipv4 at the top of the subnet list is fixed. This unblocks the CI and hence creating releases.

I've kept in the prints to debug this for future runs where something would go wrong here.

Example run of this working (as this PR doesn't have changed charts: https://github.com/accelleran/helm-charts/actions/runs/9514903996/job/26228039757)