### PR TITLE
fix: add component label to netconf service

### DIFF
--- a/charts/cell-wrapper/templates/service-netconf.yaml
+++ b/charts/cell-wrapper/templates/service-netconf.yaml
@@ -5,6 +5,7 @@
         "values" (mergeOverwrite
           (deepCopy (index $.Values "cw-ctrl"))
           (dict "service" $.Values.netconf.service)
+          (dict "component" $.Values.netconf.component)
         )
         "name" (include "accelleran.cell-wrapper.netconf.service.name" .)
       )

--- a/charts/cell-wrapper/values.yaml
+++ b/charts/cell-wrapper/values.yaml
@@ -239,6 +239,8 @@ netconf:
   nameOverride: "netconf"
   fullnameOverride: ""
 
+  component: "netconf"
+
   containerName: "netconf"
 
   image:

--- a/charts/cu-cp/templates/service-netconf.yaml
+++ b/charts/cu-cp/templates/service-netconf.yaml
@@ -5,6 +5,7 @@
         "values" (mergeOverwrite
           (deepCopy (index $.Values "cu-cp"))
           (dict "service" $.Values.netconf.service)
+          (dict "component" $.Values.netconf.component)
         )
         "name" (include "accelleran.cu-cp.netconf.service.name" .)
       )

--- a/charts/cu-cp/values.yaml
+++ b/charts/cu-cp/values.yaml
@@ -97,6 +97,8 @@ netconf:
   nameOverride: "netconf"
   fullnameOverride: ""
 
+  component: "netconf"
+
   containerName: "netconf"
 
   image:

--- a/charts/cu-up/templates/service-netconf.yaml
+++ b/charts/cu-up/templates/service-netconf.yaml
@@ -5,6 +5,7 @@
         "values" (mergeOverwrite
           (deepCopy (index $.Values "cu-up"))
           (dict "service" $.Values.netconf.service)
+          (dict "component" $.Values.netconf.component)
         )
         "name" (include "accelleran.cu-up.netconf.service.name" .)
       )

--- a/charts/cu-up/values.yaml
+++ b/charts/cu-up/values.yaml
@@ -108,6 +108,8 @@ netconf:
   nameOverride: "netconf"
   fullnameOverride: ""
 
+  component: "netconf"
+
   containerName: "netconf"
 
   image:


### PR DESCRIPTION
There is no equivalent label anymore for the "name" label since merging all the helm subcharts in a single application chart. Therefore "component" is introduced to give the ability to distinguish the service.

This will only take effect once #318 is merged, released and updated in the dependencies.