### PR TITLE
feat: add ingress templates

### DIFF
--- a/charts/common/templates/_ingress.tpl
+++ b/charts/common/templates/_ingress.tpl
@@ -1,0 +1,72 @@
+{{- define "accelleran.common.ingress" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to common ingress" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{- if $values.ingress.enabled -}}
+
+{{- $name := include "accelleran.common.ingress.name" . -}}
+{{- $annotations := include "accelleran.common.ingress.annotations" . | fromYaml -}}
+
+{{- $svcName := include "accelleran.common.service.name" . }}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+{{ include "accelleran.common.metadata" (mergeOverwrite (deepCopy .) (dict "name" $name "annotations" $annotations)) }}
+spec:
+  {{- with ($values.ingress).className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if ($values.ingress).tls }}
+  tls:
+    {{- range ($values.ingress).tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $hostIndex, $hostDetails := $values.ingress.hosts }}
+    {{- $host := $hostDetails.host }}
+    - {{- with $host }}
+      host: {{ . | quote }}
+      {{- end }}
+      http:
+        paths:
+          {{- range $hostDetails.paths }}
+          {{- $path := .path | default "/" }}
+          {{- $portName := .port | required (printf "A port needs to be provided to ingress host %v with path %v" ($host | default $hostIndex) $path) }}
+          {{- $svcPort := (get (($values.service).ports) $portName).port | required (printf "A port number needs to be provided to port %v of service %v" $portName $svcName) }}
+          - path: {{ $path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- end -}}
+
+
+{{- define "accelleran.common.ingress.name" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to common ingress name" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{- get . "name" | default (get $values.ingress "name") | default (include "accelleran.common.fullname" .) -}}
+{{- end -}}
+
+
+{{- define "accelleran.common.ingress.annotations" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to common ingress annotations" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{- with (get $values.ingress "annotations") -}}
+{{- . | toYaml -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
This PR adds an ingress template to the common library chart.

Assuming there is a service defined like this in the values file:
```
service:
  enabled: true
  ports:
    http:
      port: 5000
    websocket:
      port: 5001
```

Then we could create an ingress resource as follows with this template:
```
ingress:
  enabled: true
  className: ""
  annotations: {}
  hosts:
    - host: example.local
      paths:
        - path: /
          pathType: ImplementationSpecific
          port: http
    - host: other-example.local
      paths:
        - path: /websocket
          pathType: ImplementationSpecific
          port: websocket
  tls: []
  #  - secretName: chart-example-tls
  #    hosts:
  #      - chart-example.local
```

Note that the websocket could also be placed underneath the `example.local` host (if the paths are different at least).


There is one caveat with this implementation. It assumes there is only a single service to take the ports from. Whenever multiple services would need to be combined into a single ingress resource another implementation would be needed in that helm chart as here one ingress per service is assumed (by taking the service name from `.Values.service`).