### PR TITLE
feat: add ingress

### DIFF
--- a/charts/drax/charts/config-api/templates/ingress.yaml
+++ b/charts/drax/charts/config-api/templates/ingress.yaml
@@ -1,0 +1,4 @@
+{{- include
+      "accelleran.common.ingress"
+      (dict "top" $)
+-}}

--- a/charts/drax/charts/config-api/values.yaml
+++ b/charts/drax/charts/config-api/values.yaml
@@ -60,3 +60,19 @@ service:
       port: 80
       targetPort: 80
       protocol: TCP
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/drax/charts/dashboard/templates/ingress.yaml
+++ b/charts/drax/charts/dashboard/templates/ingress.yaml
@@ -1,0 +1,4 @@
+{{- include
+      "accelleran.common.ingress"
+      (dict "top" $)
+-}}

--- a/charts/drax/charts/dashboard/values.yaml
+++ b/charts/drax/charts/dashboard/values.yaml
@@ -102,3 +102,19 @@ service:
       targetPort: 5000
       nodePort: 31315
       protocol: TCP
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/drax/charts/network-state-monitor/templates/ingress.yaml
+++ b/charts/drax/charts/network-state-monitor/templates/ingress.yaml
@@ -1,0 +1,4 @@
+{{- include
+      "accelleran.common.ingress"
+      (dict "top" $)
+-}}

--- a/charts/drax/charts/network-state-monitor/values.yaml
+++ b/charts/drax/charts/network-state-monitor/values.yaml
@@ -79,3 +79,19 @@ service:
       port: 5000
       targetPort: 5000
       protocol: TCP
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/drax/charts/pm-counters/templates/ingress.yaml
+++ b/charts/drax/charts/pm-counters/templates/ingress.yaml
@@ -1,0 +1,4 @@
+{{- include
+      "accelleran.common.ingress"
+      (dict "top" $)
+-}}

--- a/charts/drax/charts/pm-counters/values.yaml
+++ b/charts/drax/charts/pm-counters/values.yaml
@@ -78,3 +78,19 @@ service:
       port: 8000
       protocol: TCP
       nodePort: null  # 30515
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/drax/charts/service-monitor/templates/ingress.yaml
+++ b/charts/drax/charts/service-monitor/templates/ingress.yaml
@@ -1,0 +1,4 @@
+{{- include
+      "accelleran.common.ingress"
+      (dict "top" $)
+-}}

--- a/charts/drax/charts/service-monitor/values.yaml
+++ b/charts/drax/charts/service-monitor/values.yaml
@@ -56,6 +56,22 @@ service:
       nodePort: null
       protocol: TCP
 
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/drax/charts/service-orchestrator/templates/ingress.yaml
+++ b/charts/drax/charts/service-orchestrator/templates/ingress.yaml
@@ -1,0 +1,4 @@
+{{- include
+      "accelleran.common.ingress"
+      (dict "top" $)
+-}}

--- a/charts/drax/charts/service-orchestrator/values.yaml
+++ b/charts/drax/charts/service-orchestrator/values.yaml
@@ -75,6 +75,22 @@ service:
       nodePort: null
       protocol: TCP
 
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -78,6 +78,22 @@ dashboard:
         port: 5000
         nodePort: 31315
 
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      -
+        # host: example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: http
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 
 network-state-monitor:
   # Enable/disable installation of the Network State Monitor
@@ -86,6 +102,22 @@ network-state-monitor:
   bootstrap:
     create: false
     name: "{{ $.Release.Name }}-bootstrap"
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    -
+      # host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: http
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 
 service-monitor:
@@ -98,6 +130,22 @@ service-monitor:
     enabled: "{{ $.Values.global.accelleranLicense.enabled }}"
     secretName: "{{ $.Values.global.accelleranLicense.secretName }}"
 
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      -
+        # host: example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: http
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 
 service-orchestrator:
   # Enable/disable installation of the Service Orchestrator
@@ -109,6 +157,22 @@ service-orchestrator:
     enabled: "{{ $.Values.global.accelleranLicense.enabled }}"
     secretName: "{{ $.Values.global.accelleranLicense.secretName }}"
 
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      -
+        # host: example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: http
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 
 config-api:
   enabled: true
@@ -118,6 +182,22 @@ config-api:
     default_oran_namespace_4g: "default"
     service_monitor_host: "{{ .Release.Name }}-service-monitor"
     service_monitor_port: "80"
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      -
+        # host: example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: http
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 
 cell-wrapper:
@@ -178,6 +258,22 @@ e2-t:
 
 pm-counters:
   enabled: true
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      -
+        # host: example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: http
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 
 golang-nkafka-5g:


### PR DESCRIPTION
This PR adds ingress to the drax helm charts.

Currently it's still a work in progress, and it needs to wait already for sure until:

* [x] #372 is merged, released in the common chart and the drax charts dependencies updated with this release
* [x] `accelleran/dash-front-back-end` `6.0.0` is released where http and websocket traffic are using the same port (ideally the commit [fix!: remove unused websocket port exposure](https://github.com/accelleran/helm-charts/commit/7fad9fe42556b0cfe5fa6a0130a84b69dad32986) is part of the renovate PR already

