### PR TITLE
ci: use matrix to test chart installation

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -20,13 +20,10 @@ jobs:
       is_release_branch: ${{ github.ref_type == 'branch' && startsWith(github.ref_name, 'releases/') }}
       is_pull_request: ${{ github.event_name == 'pull_request' }}
       target_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
-      charts: ${{ steps.list-charts.outputs.charts }}
+      lib_charts: ${{ steps.list-charts.outputs.lib_charts }}
       charts_to_lint: ${{ steps.list-charts.outputs.charts_to_lint }}
       charts_to_test: ${{ steps.list-charts.outputs.charts_to_test }}
-      app_charts: ${{ steps.list-charts.outputs.app_charts }}
-      lib_charts: ${{ steps.list-charts.outputs.lib_charts }}
-      lib_chart_names: ${{ steps.list-charts.outputs.lib_chart_names }}
-      chart_names_to_ignore_for_test: ${{ steps.list-charts.outputs.chart_names_to_ignore_for_test }}
+      charts_to_test_matrix: ${{ steps.list-charts.outputs.charts_to_test_matrix }}
       # renovate: github_repository=metallb/metallb versioning=semver
       metallb_version: v0.14.7
       # renovate: github_repository=halkeye/helm-repo-html versioning=semver
@@ -38,28 +35,36 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: List charts
         id: list-charts
         run: |
-          echo "charts=$(./bin/list-charts -p)" >> $GITHUB_OUTPUT
-          echo "charts_to_lint=$(./bin/list-charts -p)" >> $GITHUB_OUTPUT
-          echo "charts_to_test=$(./bin/list-charts -t -p)" >> $GITHUB_OUTPUT
-          echo "app_charts=$(./bin/list-charts -a -p)" >> $GITHUB_OUTPUT
-          echo "lib_charts=$(./bin/list-charts -l -p)" >> $GITHUB_OUTPUT
-          echo "lib_chart_names=$(./bin/list-charts -l -n)" >> $GITHUB_OUTPUT
-          echo "chart_names_to_ignore_for_test=$(./bin/list-charts -i -n)" >> $GITHUB_OUTPUT
+          echo "lib_charts=$(./bin/list-charts ${{ github.event_name == 'pull_request' && format('--changed-only --target-branch={0}', github.base_ref) || '' }} --list --delimiter=, --path lib)" | tee -a $GITHUB_OUTPUT
+          echo "charts_to_lint=$(./bin/list-charts ${{ github.event_name == 'pull_request' && format('--changed-only --target-branch={0}', github.base_ref) || '' }} --list --delimiter=, --path lint)" | tee -a $GITHUB_OUTPUT
+          echo "charts_to_test=$(./bin/list-charts ${{ github.event_name == 'pull_request' && format('--changed-only --target-branch={0}', github.base_ref) || '' }} --list --delimiter=, --path test)" | tee -a $GITHUB_OUTPUT
+          echo "charts_to_test_matrix=$(./bin/list-charts ${{ github.event_name == 'pull_request' && format('--changed-only --target-branch={0}', github.base_ref) || '' }} --matrix test)" | tee -a $GITHUB_OUTPUT
 
   lint-charts:
     name: Lint Charts
     needs:
       - vars
     runs-on: ubuntu-22.04
+    if: ${{ needs.vars.outputs.charts_to_lint != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: ${{ needs.vars.outputs.is_pull_request == 'true' && '0' || '1' }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4.2.0
@@ -76,22 +81,7 @@ jobs:
       - name: Add helm repositories
         run: ./bin/add-repos
 
-      - name: List changed
-        id: list-changed
-        run: |
-          changed_charts="${{ needs.vars.outputs.charts_to_lint }}"
-          if [ "${{ needs.vars.outputs.is_pull_request }}" == "true" ]; then
-            changed_charts="$(ct list-changed --config etc/ct.yaml --target-branch ${{ needs.vars.outputs.target_branch }})"
-          fi
-
-          if [[ -n "${changed_charts}" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Prepare library charts
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: |
           lib_charts="${{ needs.vars.outputs.lib_charts }}"
           for lc in ${lib_charts//,/ } ; do
@@ -101,29 +91,24 @@ jobs:
           done
 
       - name: Lint charts
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: >-
           ct
           lint
           --config etc/ct.yaml
-          ${{
-            needs.vars.outputs.is_pull_request == 'true' && (
-              format('--target-branch "{0}"', needs.vars.outputs.target_branch)
-            ) || (
-              format('--charts "{0}"', needs.vars.outputs.charts_to_lint)
-            )
-          }}
+          --charts ${{ needs.vars.outputs.charts_to_lint }}
 
   test-charts:
     name: Test Charts
     needs:
       - vars
+    if: ${{ needs.vars.outputs.charts_to_test != '' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.vars.outputs.charts_to_test_matrix) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: ${{ needs.vars.outputs.is_pull_request == 'true' && '0' || '1' }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4.2.0
@@ -140,32 +125,10 @@ jobs:
       - name: Add helm repositories
         run: ./bin/add-repos
 
-      - name: List changed
-        id: list-changed
-        run: |
-          changed_charts="${{ needs.vars.outputs.charts_to_test }}"
-          if [ "${{ needs.vars.outputs.is_pull_request }}" == "true" ]; then
-            changed_charts="$( \
-              ct list-changed \
-                --config etc/ct.yaml \
-                --target-branch ${{ needs.vars.outputs.target_branch }} \
-                ${{ (needs.vars.outputs.lib_chart_names && format('--excluded-charts "{0}"', needs.vars.outputs.lib_chart_names)) }} \
-                ${{ (needs.vars.outputs.chart_names_to_ignore_for_test && format('--excluded-charts "{0}"', needs.vars.outputs.chart_names_to_ignore_for_test)) }} \
-            )"
-          fi
-
-          if [[ -n "${changed_charts}" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create kind cluster
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         uses: helm/kind-action@v1.10.0
 
       - name: Install metallb for loadbalancer services
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: |
           kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${{ needs.vars.outputs.metallb_version }}/config/manifests/metallb-native.yaml
 
@@ -212,7 +175,6 @@ jobs:
           EOF
 
       - name: Create accelleran pull secret
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: >-
           kubectl create secret docker-registry
           --namespace default
@@ -221,7 +183,6 @@ jobs:
           --docker-password=${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Create accelleran license
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: |-
           cat <<EOF > license.crt
           ${{ secrets.ACCELLERAN_LICENSE }}
@@ -233,23 +194,12 @@ jobs:
           --from-file=license.crt
 
       - name: Test charts
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: >-
           ct
           install
           --namespace default
           --config etc/ct.yaml
-          ${{
-            needs.vars.outputs.is_pull_request == 'true' && (
-              format('--target-branch "{0}" --excluded-charts "{1}" --excluded-charts "{2}"',
-                needs.vars.outputs.target_branch,
-                needs.vars.outputs.lib_chart_names,
-                needs.vars.outputs.chart_names_to_ignore_for_test
-              )
-            ) || (
-              format('--charts "{0}"', needs.vars.outputs.charts_to_test)
-            )
-          }}
+          --charts ${{ matrix.chart_path }}
           --helm-extra-set-args "--set=kafka.provisioning.useHelmHooks=false"
 
   release-charts:

--- a/bin/list-charts
+++ b/bin/list-charts
@@ -1,88 +1,254 @@
-#!/bin/bash
+#!/usr/bin/python3
 
-GIT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+import argparse
+from dataclasses import dataclass
+import json
+import os
+import subprocess
+import yaml
 
-function usage() {
-    echo "Usage:"
-    echo "list-charts"
-    echo "    -h                      Display usage."
-    echo "    -a                      List only application charts."
-    echo "    -l                      List only library charts."
-    echo "    -i                      List ignored install charts."
-    echo "    -n                      List charts by name."
-    echo "    -p                      List charts by path."
-    exit 0
-}
 
-function error() {
-    echo "${1}" 1>&2
-    exit 1
-}
+@dataclass
+class Chart:
+    name: str
+    path: str
 
-list_application_charts=false
-list_library_charts=false
 
-list_charts_to_ignore_for_test=false
-list_charts_to_test=false
+def main():
+    args = get_args()
 
-list_chart_names=false
+    charts = get_charts(args.type, args.changed_only, args.target_branch)
+    output = generate_output_charts(
+        charts, args.output, args.chart_output, args.delimiter
+    )
+    print(output)
 
-while getopts ":halitnp" opt; do
-    case ${opt} in
-        h )
-            usage
-        ;;
-        a )
-            list_application_charts=true
-        ;;
-        l )
-            list_library_charts=true
-        ;;
-        i )
-            list_charts_to_ignore_for_test=true
-        ;;
-        t )
-            list_charts_to_test=true
-        ;;
-        n )
-            list_chart_names=true
-        ;;
-        p )
-            list_chart_names=false
-        ;;
-        \? )
-            error "Invalid Option: -${OPTARG}"
-        ;;
-    esac
-done
-shift $((OPTIND -1))
 
-if [[ "${list_application_charts}" == false && "${list_library_charts}" == false && "${list_charts_to_ignore_for_test}" == false && "${list_charts_to_test}" == false ]]; then
-    list_application_charts=true
-    list_library_charts=true
-fi
+def get_args():
+    msg = "List charts in different ways to use with ct"
+    parser = argparse.ArgumentParser(msg)
 
-if [[ "${list_charts_to_ignore_for_test}" == true ]]; then
-    chart_paths=$(find "${GIT_ROOT}"/charts/ -type d -exec sh -c 'test -f ${0}/Chart.yaml -a -f ${0}/.ct-install-ignore && echo ${0}/Chart.yaml' {} \;)
-elif [[ "${list_charts_to_test}" == true ]]; then
-    chart_paths=$(find "${GIT_ROOT}"/charts/ -type d -exec sh -c 'test -f ${0}/Chart.yaml -a ! -f ${0}/.ct-install-ignore && yq -e '\''.type == "application"'\'' ${0}/Chart.yaml >/dev/null 2>&1 && echo ${0}' {} \;)
-elif [[ "${list_application_charts}" == true && "${list_library_charts}" == true ]]; then
-    chart_paths=$(find "${GIT_ROOT}"/charts/ -type f -name 'Chart.yaml')
-elif [[ "${list_application_charts}" == true ]]; then
-    chart_paths=$(find "${GIT_ROOT}"/charts/ -type f -name 'Chart.yaml' -exec sh -c 'yq -e '\''.type == "application"'\'' ${0} >/dev/null 2>&1 && echo ${0}' {} \;)
-elif [[ "${list_library_charts}" == true ]]; then
-    chart_paths=$(find "${GIT_ROOT}"/charts/ -type f -name 'Chart.yaml' -exec sh -c 'yq -e '\''.type == "library"'\'' ${0} >/dev/null 2>&1 && echo ${0}' {} \;)
-fi
+    parser.add_argument(
+        "type",
+        nargs="?",
+        choices=["lint", "test", "all", "app", "lib"],
+        default="all",
+        help="Show all charts (all), application charts (app), library charts (lib), charts to ct lint (lint) or to ct test (test)",
+    )
 
-chart_paths=$(echo "${chart_paths}" | sed -r 's|/(Chart\.yaml)?$||' | sort -u | sed -z 's/\n/,/g;s/,$/\n/')
+    parser.add_argument(
+        "-l",
+        "--list",
+        action="store_const",
+        const="list",
+        dest="output",
+        default="list",
+        help="Show charts in a list",
+    )
+    parser.add_argument(
+        "-m",
+        "--matrix",
+        action="store_const",
+        const="matrix",
+        dest="output",
+        help="Show charts in a GitHub Actions matrix",
+    )
 
-if [[ "${list_chart_names}" == true ]] ; then
-    chart_names=""
-    for lc in ${chart_paths//,/ } ; do
-        chart_names+="$(basename "${lc}"),"
-    done
+    parser.add_argument(
+        "-n",
+        "--name",
+        action="store_const",
+        const="name",
+        dest="chart_output",
+        default="name",
+        help="Output charts by name",
+    )
+    parser.add_argument(
+        "-p",
+        "--path",
+        action="store_const",
+        const="path",
+        dest="chart_output",
+        help="Show charts by path",
+    )
 
-    echo "${chart_names}" | sed -r 's/,$//g'
-else
-    echo "${chart_paths}"
-fi
+    parser.add_argument(
+        "-d",
+        "--delimiter",
+        default="\r\n",
+        help="Set the delimiter to show charts in a list",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--changed-only",
+        action="store_true",
+        help="Only show changed charts compared to the target branch",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--target-branch",
+        default="main",
+        help="The target branch to compare with when only showing changed charts (default=main)",
+    )
+
+    return parser.parse_args()
+
+
+def get_charts(type: str, changed_only: bool, target_branch: str) -> list[Chart]:
+    if changed_only:
+        charts = get_changed_charts(
+            os.path.join(get_git_root_path(), "charts"), target_branch
+        )
+    else:
+        charts = get_all_charts(get_git_root_path())
+
+    filters = {
+        "all": lambda _: True,
+        "app": is_app_chart,
+        "lib": is_lib_chart,
+        "lint": is_chart_to_lint,
+        "test": is_chart_to_test,
+    }
+
+    return list(filter(filters[type], charts))
+
+
+def get_git_root_path() -> str:
+    bin_dir_path = os.path.dirname(os.path.realpath(__file__))
+    git_root_path = os.path.abspath(os.path.join(bin_dir_path, os.pardir))
+
+    return git_root_path
+
+
+def get_changed_charts(path: str, target_branch: str) -> list[Chart]:
+    if os.path.isfile(path):
+        return []
+
+    charts: list[Chart] = []
+
+    changed_chart_paths = get_changed_chart_paths(path, target_branch)
+    for changed_chart_path in changed_chart_paths:
+        changed_chart_name = os.path.basename(changed_chart_path)
+        chart = Chart(name=changed_chart_name, path=changed_chart_path)
+        charts.append(chart)
+
+    for fd in os.listdir(path):
+        new_path = os.path.join(path, fd)
+        if os.path.isdir(new_path):
+            charts += get_changed_charts(new_path, target_branch)
+
+    return charts
+
+
+def get_changed_chart_paths(path: str, target_branch: str) -> list[str]:
+    git_root_path: str = get_git_root_path()
+    config_file_path: str = os.path.join(git_root_path, "etc/ct.yaml")
+    chart_dir: str = os.path.relpath(path, git_root_path)
+
+    completed_process = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            f"cd {git_root_path} && ct list-changed --config {config_file_path} --target-branch {target_branch} --chart-dirs {chart_dir}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if completed_process.returncode != 0:
+        return []
+
+    if completed_process.stdout == "":
+        return []
+
+    relative_chart_paths = completed_process.stdout.strip("\n").split("\n")
+    return [
+        os.path.join(git_root_path, relative_chart_path)
+        for relative_chart_path in relative_chart_paths
+    ]
+
+
+def get_all_charts(path: str) -> list[Chart]:
+    if os.path.isfile(path):
+        return []
+
+    charts: list[Chart] = []
+
+    if is_chart_dir(path):
+        chart_name = os.path.basename(path)
+        chart = Chart(name=chart_name, path=path)
+        charts.append(chart)
+
+    for fd in os.listdir(path):
+        new_path = os.path.join(path, fd)
+        if os.path.isdir(new_path):
+            charts += get_all_charts(new_path)
+
+    return charts
+
+
+def is_chart_dir(path: str) -> bool:
+    return os.path.isfile(get_chart_yaml_path(path))
+
+
+def get_chart_yaml_path(chart_path: str) -> str:
+    return os.path.join(chart_path, "Chart.yaml")
+
+
+def is_chart_to_lint(chart: Chart) -> bool:
+    return True
+
+
+def is_chart_to_test(chart: Chart) -> bool:
+    return is_app_chart(chart) and not is_ignored_chart_for_test(chart)
+
+
+def is_app_chart(chart: Chart) -> bool:
+    with open(get_chart_yaml_path(chart.path), "r") as f:
+        data = yaml.safe_load(f)
+        return data.get("type") == "application"
+
+
+def is_lib_chart(chart: Chart) -> bool:
+    with open(get_chart_yaml_path(chart.path), "r") as f:
+        data = yaml.safe_load(f)
+        return data.get("type") == "library"
+
+
+def is_ignored_chart_for_test(chart: Chart) -> bool:
+    return os.path.isfile(get_ignored_chart_for_test_path(chart.path))
+
+
+def get_ignored_chart_for_test_path(chart_path: str) -> str:
+    return os.path.join(chart_path, ".ct-install-ignore")
+
+
+def generate_output_charts(
+    charts: list[Chart], output: str, charts_output: str, delimiter: str
+) -> str:
+    chart_names: list[str] = [chart.name for chart in charts]
+    chart_paths = [chart.path for chart in charts]
+
+    if output == "list":
+        if charts_output == "path":
+            charts = chart_paths
+        else:
+            charts = chart_names
+
+        return delimiter.join(charts)
+
+    if output == "matrix":
+        return json.dumps(
+            {
+                "chart": chart_names,
+                "include": [
+                    {"chart": chart.name, "chart_path": chart.path} for chart in charts
+                ],
+            }
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In this PR a matrix strategy is used for the `ct install` tests.

Mainly with the `drax` helm chart being so slow to deploy it takes a while to sequentially do this for all the charts in the repo. With the matrix everything is running in parallel (note that kind with metallb is now deployed each time as "overhead").

The trick to make this work is to have a dynamic matrix config injected with `fromJSON`. The actual data is created within the `Variables` step in `list-charts`. `list-charts` now contains a lot more complexity, but it takes this away from the workflow (python vs yaml). Now there is no need anymore to do different stuff if we're working on top of a PR or `main`, this is all hidden away within `list-charts` by just exposing the charts that our workflow needs to work with.

Another thing that's fixed by this way of working is the nested chart directories. From now on also for example `config-api`, a subchart of `drax`, will be linted (and tested if it wouldn't have an ignore file) for example as part of a PR instead of only once it's merged to the `main` branch.

Originally this was implemented in [my own helm charts repository](https://github.com/wielewout/helm-charts), so you can have a look over there of it working.

Edit: another advantage of this approach is that it becomes easier to find the issue when something is failing. As the logs are enormous (print out of generated values, k8s resources, pod descriptions with pod logs, the test results and the uninstall logs) it's hard to find the correct chart context to look into for issues. Now everything is isolated and thus there will always be just one chart for context.