### PR TITLE
fix: add option to not set ingress tls secret name or hosts

### DIFF
--- a/charts/common/templates/_ingress.tpl
+++ b/charts/common/templates/_ingress.tpl
@@ -19,11 +19,16 @@ spec:
   {{- if ($values.ingress).tls }}
   tls:
     {{- range ($values.ingress).tls }}
-    - hosts:
-        {{- range .hosts }}
+    - 
+      {{- with .hosts }}
+      hosts:
+        {{- range . }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      {{- end }}
+      {{- with .secretName }}
+      secretName: {{ . | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   rules:


### PR DESCRIPTION
It allows to for example pass down the following values:

```yaml
ingress:
  enabled: true
  hosts:
    - paths:
        - path: /
          pathType: ImplementationSpecific
          port: http
  tls:
    - {}
```

With nginx-ingress for example this results in using a default self-signed certifiicate and forced redirection to https.