### PR TITLE
feat: add pod template

### DIFF
--- a/charts/common/templates/_pod.tpl
+++ b/charts/common/templates/_pod.tpl
@@ -1,3 +1,13 @@
+{{- define "accelleran.common.pod" -}}
+apiVersion: v1
+kind: Pod
+{{ toYaml (merge
+    (fromYaml (include "accelleran.common.metadata" .))
+    (fromYaml (include "accelleran.common.pod.tpl" .))
+) }}
+{{- end -}}
+
+
 {{- define "accelleran.common.pod.tpl" -}}
 {{- $ := get . "top" | required "The top context needs to be provided to common pod tpl" -}}
 {{- $values := get . "values" | default $.Values -}}


### PR DESCRIPTION
This PR adds a template for a pod. I ended up using a job when fixing something as part of the loki-notifications, but this pod template can be useful when prototyping something.