### PR TITLE
feat: allow to inject templates in annotations

### DIFF
--- a/charts/common/templates/_annotations.tpl
+++ b/charts/common/templates/_annotations.tpl
@@ -8,7 +8,7 @@
 {{- $annotations | toYaml }}
 {{- else -}}
 {{- with $values.annotations -}}
-{{ toYaml . }}
+{{ tpl (toYaml .) $ }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/common/templates/_ingress.tpl
+++ b/charts/common/templates/_ingress.tpl
@@ -72,6 +72,6 @@ spec:
 {{- $values := get . "values" | default $.Values -}}
 
 {{- with (get $values.ingress "annotations") -}}
-{{- . | toYaml -}}
+{{- tpl (toYaml .) $ -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
For example in traefik middleware, the namespace should be added within the ingress' annotation like the following:

```
traefik.ingress.kubernetes.io/router.middlewares: "{{ $.Release.Namespace }}-strip-prefix@kubernetescrd"
```