### PR TITLE
fix: adapt dashboard to loki-gateway changes

### DIFF
--- a/charts/drax/charts/dashboard/templates/deployment.yaml
+++ b/charts/drax/charts/dashboard/templates/deployment.yaml
@@ -13,13 +13,23 @@ top:
 initContainers:
 - {{ fromYaml (include "accelleran.common.init.kafka" (dict "top" $)) | toYaml | nindent 2 }}
 
-{{- with tpl $.Values.config.draxVersionConfigmap $ }}
+{{- if or (tpl $.Values.config.draxVersionConfigmap $) .Values.secretRefs }}
 env:
+  {{- with tpl $.Values.config.draxVersionConfigmap $ }}
   - name: DRAX_VERSION
     valueFrom:
       configMapKeyRef:
         name: {{ . }}
         key: draxVersion
+  {{- end }}
+
+  {{- range .Values.secretRefs }}
+  - name: {{ .name }}
+    valueFrom:
+      secretKeyRef:
+        name: {{ tpl .secretName $ }}
+        key: {{ .secretKey }}
+  {{- end }}
 {{- end }}
 
 volumes:

--- a/charts/drax/charts/dashboard/values.yaml
+++ b/charts/drax/charts/dashboard/values.yaml
@@ -28,6 +28,8 @@ config:
   svcMonitorPort: 80
   svcOrchestratorHost: ""
   svcOrchestratorPort: 80
+  lokiHost: ""
+  lokiPort: ""
   configApiHost: ""
   configApiPort: 80
   pcixAppPodName: ""

--- a/charts/drax/charts/dashboard/values.yaml
+++ b/charts/drax/charts/dashboard/values.yaml
@@ -122,3 +122,5 @@ ingress:
   #      - chart-example.local
 
 extraResources: []
+
+extraEnvs: []

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -82,6 +82,10 @@ dashboard:
     # Defined for environment variable DRAX_VERSION
     draxVersionConfigmap: "{{ $.Release.Name }}-version"
 
+  extraEnvs:
+  - name: "LOKI_NOTIFICATIONS_BASIC_AUTH_USERNAME"
+    value: "dashboard-notifications"
+  
   service:
     type: NodePort
     ports:

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -60,6 +60,11 @@ dashboard:
     create: false
     name: "{{ $.Release.Name }}-bootstrap"
 
+  secretRefs:
+  - name: "LOKI_NOTIFICATIONS_BASIC_AUTH_PASSWORD"
+    secretName: "{{ $.Release.Name }}-loki-gateway-auth"
+    secretKey: "dashboard-notifications"
+
   config:
     # Defined for server config.json
     kafkaURL: "{{ $.Release.Name }}-kafka"
@@ -68,6 +73,8 @@ dashboard:
     svcOrchestratorHost: "{{ $.Release.Name }}-service-orchestrator"
     configApiHost: "{{ $.Release.Name }}-config-api"
     pcixAppPodName: "accelleran-drax-pci-010-pci-xapp-api"
+    lokiHost: "{{ .Release.Name }}-loki-gateway.{{ .Release.Namespace }}"
+    lokiPort: "80"
     ksqldbPodName: "{{ $.Values.global.kubeIp }}"
     nodeApiURL: "{{ $.Values.global.kubeIp }}"
     # Defined for core-ui config.js
@@ -1022,6 +1029,9 @@ loki-gateway:
         password: ""
         organization: "notifications"
       - username: "grafana-notifications"
+        password: ""
+        organization: "notifications"
+      - username: "dashboard-notifications"
         password: ""
         organization: "notifications"
 

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -85,7 +85,7 @@ dashboard:
   extraEnvs:
   - name: "LOKI_NOTIFICATIONS_BASIC_AUTH_USERNAME"
     value: "dashboard-notifications"
-  
+
   service:
     type: NodePort
     ports:


### PR DESCRIPTION
This injects the loki-gateway secret to the dashboard helm chart such that it will be able to query Loki for the notifications