### PR TITLE
fix: keep du influxdb auth secret on uninstall

### DIFF
--- a/charts/drax/templates/secret-du-influxdb.yaml
+++ b/charts/drax/templates/secret-du-influxdb.yaml
@@ -1,0 +1,13 @@
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "drax-du-influxdb-auth" -}}
+{{- if not $existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: drax-du-influxdb-auth
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+  admin-token: {{ index $.Values "du-metrics-server" "influxdb" "adminUser" "token" | default (randAlphaNum 48) | b64enc | quote}}
+  admin-password: {{ index $.Values "du-metrics-server" "influxdb" "adminUser" "password" | default (randAlphaNum 48) | b64enc | quote }}
+{{- end }}

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -247,6 +247,15 @@ du-metrics-server:
   influxdb:
     nameOverride: "du-influxdb"
 
+    adminUser:
+      organization: "accelleran"
+      bucket: "default"
+      retention_policy: "0s"
+      user: "admin"
+      password: ""
+      token: ""
+      existingSecret: drax-du-influxdb-auth
+
     persistence:
       enabled: true
       accessMode: ReadWriteOnce
@@ -720,12 +729,14 @@ grafana:
   envValueFrom:
     DU_INFLUXDB_ADMIN_TOKEN:
       secretKeyRef:
-        name: "{{ $.Release.Name }}-du-influxdb-auth"
+        name: "drax-du-influxdb-auth"
         key: admin-token
+
     LOKI_LOGS_BASIC_AUTH_PASSWORD:
       secretKeyRef:
         name: "{{ $.Release.Name }}-loki-gateway-auth"
         key: grafana-logs
+
     LOKI_NOTIFICATIONS_BASIC_AUTH_PASSWORD:
       secretKeyRef:
         name: "{{ $.Release.Name }}-loki-gateway-auth"


### PR DESCRIPTION
This adds a secret similar to `influxdb2`, but for the du metrics. This was added on the drax level as the `drax-` prefix is then only fixed for the drax chart and not for the `du-metrics-server`.