### PR TITLE
fix: use random alpha numeric passwords

### DIFF
--- a/charts/loki-gateway/templates/secret-auth.yaml
+++ b/charts/loki-gateway/templates/secret-auth.yaml
@@ -16,7 +16,7 @@
 {{- $users := dict -}}
 {{- range $index, $user := $.Values.auth.users -}}
 {{- $username := $user.username | required (printf "A username is required when auth is enabled in loki-gateway (auth.users[%d].username)" $index) -}}
-{{- $password := $user.password | default (randAscii 48) -}}
+{{- $password := $user.password | default (randAlphaNum 48) -}}
 {{- $_ := set $users $username $password -}}
 {{- end -}}
 


### PR DESCRIPTION
This prevents escaping issues due to randomly generated backslashes in the password string. In for example grafana this was providing issues.