### PR TITLE
fix: fix service selector labels

### DIFF
--- a/charts/cu-cp/templates/deployment-cu-cp.yaml
+++ b/charts/cu-cp/templates/deployment-cu-cp.yaml
@@ -13,6 +13,12 @@ top:
 values:
   {{ $values | toYaml | nindent 2 }}
 
+selectorLabels:
+  {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
+  app.kubernetes.io/component: {{ $values.component }}
+labels:
+  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
+
 initContainers:
 - {{ fromYaml (include "accelleran.common.init.redis" (fromYaml (include "accelleran.cu-cp.init.args" .))) | toYaml | nindent 2 }}
 - {{ fromYaml (include "accelleran.common.init.nats" (fromYaml (include "accelleran.cu-cp.init.args" .))) | toYaml | nindent 2 }}

--- a/charts/cu-cp/templates/service-e1.yaml
+++ b/charts/cu-cp/templates/service-e1.yaml
@@ -1,11 +1,17 @@
+{{- $values := index $.Values "cu-cp" -}}
 {{- include
       "accelleran.common.service"
       (dict
         "top" $
         "values" (mergeOverwrite
-          (deepCopy (index $.Values "cu-cp"))
+          (deepCopy $values)
           (dict "service" (index $.Values "sctp-e1" "service"))
           (dict "service" (dict "name" (include "accelleran.cu-cp.e1.service.name" .)))
         )
+        "selectorLabels" (merge
+          (include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | fromYaml)
+          (dict "app.kubernetes.io/component" $values.component)
+        )
+        "labels" (include "accelleran.common.labels" (dict "top" $ "values" $values) | fromYaml)
       )
 -}}

--- a/charts/cu-cp/templates/service-f1.yaml
+++ b/charts/cu-cp/templates/service-f1.yaml
@@ -1,11 +1,17 @@
+{{- $values := index $.Values "cu-cp" -}}
 {{- include
       "accelleran.common.service"
       (dict
         "top" $
         "values" (mergeOverwrite
-          (deepCopy (index $.Values "cu-cp"))
+          (deepCopy $values)
           (dict "service" (index $.Values "sctp-f1" "service"))
           (dict "service" (dict "name" (include "accelleran.cu-cp.f1.service.name" .)))
         )
+        "selectorLabels" (merge
+          (include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | fromYaml)
+          (dict "app.kubernetes.io/component" $values.component)
+        )
+        "labels" (include "accelleran.common.labels" (dict "top" $ "values" $values) | fromYaml)
       )
 -}}

--- a/charts/cu-cp/values.yaml
+++ b/charts/cu-cp/values.yaml
@@ -62,6 +62,8 @@ cu-cp:
   nameOverride: "cu-cp"
   fullnameOverride: ""
 
+  component: "cu-cp"
+
   redisInitImage:
     repository: accelleran/acc-generic-img
     tag: "0.8.1"


### PR DESCRIPTION
This fixes the f1 and e1 service also matching the netconf pod. A component label is added to separate f1 and e1 from netconf.