### PR TITLE
feat: add more config options

### DIFF
--- a/charts/common/templates/_configmap.tpl
+++ b/charts/common/templates/_configmap.tpl
@@ -3,10 +3,15 @@
 {{- $values := get . "values" | default $.Values -}}
 
 {{- $data := get . "data" | default dict -}}
+{{- $binaryData := get . "binaryData" | default dict -}}
 
 apiVersion: v1
 kind: ConfigMap
 {{ include "accelleran.common.metadata" . }}
-data:
-  {{- $data | toYaml | nindent 2 -}}
+{{- with $data }}
+data: {{ . | toYaml | nindent 2 }}
+{{- end }}
+{{- with $binaryData }}
+binaryData: {{ . | toYaml | nindent 2 }}
+{{- end }}
 {{- end -}}

--- a/charts/common/templates/_container.tpl
+++ b/charts/common/templates/_container.tpl
@@ -4,8 +4,8 @@
 
 {{- $containerName := $values.containerName | default (include "accelleran.common.name" .) -}}
 
-{{- $command := $values.command -}}
-{{- $args := $values.args -}}
+{{- $command := get . "command" | default $values.command -}}
+{{- $args := get . "args" | default $values.args -}}
 
 {{- $env := get . "env" | default list -}}
 {{- with $values.extraEnvs -}}

--- a/charts/common/templates/_job.tpl
+++ b/charts/common/templates/_job.tpl
@@ -11,13 +11,16 @@ kind: Job
 {{- define "accelleran.common.job.tpl" -}}
 {{- $ := get . "top" | required "The top context needs to be provided to common job tpl" -}}
 
+{{- $ttlSecondsAfterFinished := get . "ttlSecondsAfterFinished" -}}
 {{- $backoffLimit := get . "backoffLimit" -}}
 
 metadata:
   labels:
     {{- include "accelleran.common.labels" . | nindent 4 }}
 spec:
-  # ttlSecondsAfterFinished: 600 # k8s v1.23
+  {{- with $ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
   {{- with $backoffLimit }}
   backoffLimit: {{ . }}
   {{- end }}

--- a/charts/common/templates/_labels.tpl
+++ b/charts/common/templates/_labels.tpl
@@ -25,7 +25,9 @@ helm.sh/chart: {{ include "accelleran.common.chart" . }}
 {{- with (include "accelleran.common.component" .) }}
 app.kubernetes.io/component: {{ . | quote }}
 {{- end }}
-app.kubernetes.io/version: {{ include "accelleran.common.appVersion" . | quote }}
+{{- with (include "accelleran.common.appVersion" . | default (include "accelleran.common.helmVersion" .)) }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
 {{- with (include "accelleran.common.partOf" .) }}
 app.kubernetes.io/part-of: {{ . | quote }}
 {{- end }}

--- a/charts/common/templates/_service.tpl
+++ b/charts/common/templates/_service.tpl
@@ -19,7 +19,7 @@ spec:
   clusterIP: {{ . }}
   {{- end }}
   {{- if eq $type "LoadBalancer" -}}
-  {{- with $values.service.loadBalancerIP }}
+  {{- with tpl $values.service.loadBalancerIP $ }}
   loadBalancerIP: {{ . }}
   {{- end }}
   {{- end }}

--- a/charts/common/templates/_version.tpl
+++ b/charts/common/templates/_version.tpl
@@ -13,7 +13,10 @@ Work-around as .Chart.AppVersion is undefined with (de)serializations (from/toYa
 This can not be used with `default` as then it would be evaluated,
 resulting in a failure when no (de)serializations took place.
 */ -}}
-{{- $version = $.Chart.appVersion -}}
+{{- $chart := $.Chart | toYaml | fromYaml -}}
+{{- with get $chart "appVersion" -}}
+{{- $version = . -}}
+{{- end -}}
 {{- end -}}
 
 {{- $version -}}


### PR DESCRIPTION
This PR adds more config options that will mainly be used with the introduction of authentication to drax. Also the app version is fixed when it's missing in the `Chart.yaml` file.

This PR is meant to be merged with a rebase (to add all commits to the common chart release notes).

Related to #595