### PR TITLE
fix: add an external logs user by default

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -944,6 +944,9 @@ loki-gateway:
       - username: "dashboard-notifications"
         password: ""
         organization: "notifications"
+      - username: "external-logs"
+        password: ""
+        organization: "logs"
 
   ingress:
     enabled: false


### PR DESCRIPTION
With the introduction of notifications in loki, there was also a need for authentication. Now an `external-logs` user is added by default as well for an external promtail instance for example.