### PR TITLE
feat: add e2sm-ccc deployment template

### DIFF
--- a/charts/drax/charts/e2-t/templates/deployment-e2-t-sm-ccc.yaml
+++ b/charts/drax/charts/e2-t/templates/deployment-e2-t-sm-ccc.yaml
@@ -1,0 +1,33 @@
+{{- include
+      "accelleran.common.deployment"
+      (fromYaml (include "accelleran.e2-t.sm-ccc.deployment.args" $))
+-}}
+
+{{- define "accelleran.e2-t.sm-ccc.deployment.args" -}}
+{{- $ := . -}}
+{{- $values := index $.Values "e2-t-sm-ccc" -}}
+
+top:
+  {{ $ | toYaml | nindent 2 }}
+values:
+  {{ $values | toYaml | nindent 2 }}
+
+initContainers:
+- {{ fromYaml (include "accelleran.common.init.redis" (fromYaml (include "accelleran.e2-t.init.args" .))) | toYaml | nindent 2 }}
+- {{ fromYaml (include "accelleran.common.init.nats" (fromYaml (include "accelleran.e2-t.init.args" .))) | toYaml | nindent 2 }}
+
+env:
+  - name: __APPNAME
+    value: e2TSmCcc
+  - name: __APPID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+{{- with (include "accelleran.common.bootstrap.instanceId" (dict "top" $)) }}
+  - name: INSTANCE_FILTER
+    value: {{ . | quote }}
+{{- end }}
+envFrom:
+  - configMapRef:
+      name: {{ include "accelleran.common.bootstrap.configMapName" (dict "top" $) | quote }}
+{{- end -}}

--- a/charts/drax/charts/e2-t/values.yaml
+++ b/charts/drax/charts/e2-t/values.yaml
@@ -254,6 +254,51 @@ e2-t-sm-rc:
 
   affinity: {}
 
+e2-t-sm-ccc:
+  enabled: true
+
+  nameOverride: "e2-t-sm-ccc"
+  fullnameOverride: ""
+
+  containerName: "e2-t-sm-ccc"
+
+  replicaCount: 1
+
+  image:
+    repository: accelleran/e2smcccappl
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  accelleranLicense:
+    enabled: false
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 0
+    # privileged: true
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
 
 nats:
   enabled: false


### PR DESCRIPTION
This was a branch Antoine created to include the ccc pod in the e2 broker and gave Mahmoud a while ago. This should be part of drax 10.