### PR TITLE
fix: add retention to kafka to prevent node disk pressure

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -454,9 +454,6 @@ kafka:
       value: "true"
 
   extraConfigYaml:
-    segment.ms: 86400000  # 24h
-    segment.bytes: 268435456  # 0.25GiB
-
     log.retention.ms: 604800000  # 7d
     log.retention.bytes: 4294967296  # 4GiB
     log.roll.ms: 86400000  # 24h

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -454,8 +454,6 @@ kafka:
       value: "true"
 
   extraConfigYaml:
-    retention.ms: 604800000  # 7d
-    retention.bytes: 4294967296  # 4GiB
     segment.ms: 86400000  # 24h
     segment.bytes: 268435456  # 0.25GiB
 

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -453,6 +453,20 @@ kafka:
     - name: "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE"
       value: "true"
 
+  extraConfigYaml:
+    retention.ms: 604800000  # 7d
+    retention.bytes: 4294967296  # 4GiB
+    segment.ms: 86400000  # 24h
+    segment.bytes: 268435456  # 0.25GiB
+
+    log.retention.ms: 604800000  # 7d
+    log.retention.bytes: 4294967296  # 4GiB
+    log.roll.ms: 86400000  # 24h
+    log.segment.bytes: 268435456  # 0.25GiB
+
+    log.local.retention.ms: 604800000  # 7d
+    log.local.retention.bytes: 4294967296  # 4GiB
+
   listeners:
     client:
       name: CLIENT
@@ -479,14 +493,14 @@ kafka:
     automountServiceAccountToken: true
     nodeSelector: {}
     persistence:
-      size: 1Gi
+      size: 5Gi
     resourcesPreset: medium
 
   broker:
     automountServiceAccountToken: true
     nodeSelector: {}
     persistence:
-      size: 1Gi
+      size: 5Gi
     resourcesPreset: medium
 
   provisioning:


### PR DESCRIPTION
In this PR retention is added to kafka to prevent getting into disk pressure on a node.

After either 7 days or if more than 4GiB is used the data is deleted. I've also adjusted the pvc sizes to 5GiB to match those 4GiB with some overhead. There could be other data, plus the deletion of data is checked every 5 minutes by default, so we can use more than 4GiB too for a small amount of time. E.g. with local-path-provisioner this size wouldn't be enforced, but for example with longhorn as a storage class it could, so in those cases this overhead might still require some adjusting.

The most important settings (I think) are `log.local.retention.*`. Those are the ones I could clearly see in the logs of the kafka controllers at least.