### PR TITLE
fix!: limit minio to a single drive

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1290,8 +1290,7 @@ loki-deleter:
 
     # the names depend on minio.replicas and minio.drivesPerNode
     pvcNames:
-      - "export-0-{{ $.Release.Name }}-minio-0"
-      - "export-1-{{ $.Release.Name }}-minio-0"
+      - "{{ $.Release.Name }}-minio"
 
     localPath: "/opt/local-path-provisioner"
 
@@ -1317,9 +1316,13 @@ minio:
   # Minio requires 2 to 16 drives for erasure code (drivesPerNode * replicas)
   # https://docs.min.io/docs/minio-erasure-code-quickstart-guide
   # Since we only have 1 replica, that means 2 drives must be used.
-  drivesPerNode: 2
+  # But for now we want to limit the amount of storage used, so 1 drive.
+  drivesPerNode: 1
   rootUser: ""
   rootPassword: ""
+
+  # With 1 replica and 1 drive we need to run in standalone mode
+  mode: standalone
 
   # Allow the address used by Loki to refer to Minio to be overridden
   address: null


### PR DESCRIPTION
In our typical deployment we don't have multiple disks, so limiting it by default to 1 drive. The only advantages that the 2 disks would provide are disk loss and failover (but in our case both "disks" would be affected at the same time, as there is only 1, so there would be nothing to fall back to). Downsides it's giving is mainly twice the amount of data on disk.

This is a breaking change as a deployment would be used due to the stand-alone mode and with that also a pvc would be created separately (as no pvc template would be used as part of the statefulset).

As the pvc would change, there is also manual cleanup required from a user when upgrading...

Todo:
- [x] Adapt loki-deleter to the new pvc