### PR TITLE
fix: set loki retention delete delay

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -993,6 +993,7 @@ loki:
         retention_enabled: true
         delete_request_store: s3
         delete_request_cancel_period: 1m
+        retention_delete_delay: 10m
       runtime_config:
         file: "/runtime-config/tenants.yaml"
 

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -991,6 +991,7 @@ loki:
         max_entries_limit_per_query: 10000
       compactor:
         retention_enabled: true
+        compaction_interval: 10m
         delete_request_store: s3
         delete_request_cancel_period: 1m
         retention_delete_delay: 10m


### PR DESCRIPTION
Lower the retention delete delay to 10m to have data deleted faster from disk.