### PR TITLE
fix!: drop debug and trace messages for loki storage

### DIFF
--- a/charts/drax/configuration/grafana/dashboards/loki-log-dashboard.json
+++ b/charts/drax/configuration/grafana/dashboards/loki-log-dashboard.json
@@ -15,13 +15,12 @@
       }
     ]
   },
-  "description": "Loki logs panel with prometheus variables ",
+  "description": "Loki logs panel",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": 12019,
   "graphTooltip": 0,
+  "id": 1,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "datasource": {
@@ -105,14 +104,14 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "P8E80F9AEF21F6940"
           },
-          "expr": "sum(count_over_time({node_name=~\"$node\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |~ `$line_search`[$__interval]))",
+          "expr": "sum(count_over_time({node_name=~\"$node\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", level=~\"$level\"} |~ `$line_search`[$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -126,6 +125,10 @@
         "uid": "P8E80F9AEF21F6940"
       },
       "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 24,
         "w": 24,
@@ -144,13 +147,14 @@
         "sortOrder": "Ascending",
         "wrapLogMessage": true
       },
+      "pluginVersion": "11.3.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "P8E80F9AEF21F6940"
           },
-          "expr": "{node_name=~\"$node\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |~ `$line_search`",
+          "expr": "{node_name=~\"$node\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", level=~\"$level\"} |~ `$line_search`",
           "hide": false,
           "maxLines": 1000,
           "queryType": "range",
@@ -161,15 +165,15 @@
       "type": "logs"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [],
   "templating": {
     "list": [
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -182,7 +186,6 @@
           "uid": "P8E80F9AEF21F6940"
         },
         "definition": "",
-        "hide": 0,
         "includeAll": true,
         "label": "Node",
         "multi": true,
@@ -196,17 +199,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -219,7 +217,6 @@
           "uid": "P8E80F9AEF21F6940"
         },
         "definition": "",
-        "hide": 0,
         "includeAll": true,
         "label": "Namespace",
         "multi": true,
@@ -233,17 +230,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -256,7 +248,6 @@
           "uid": "P8E80F9AEF21F6940"
         },
         "definition": "",
-        "hide": 0,
         "includeAll": true,
         "label": "Pod",
         "multi": true,
@@ -270,17 +261,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -293,7 +279,6 @@
           "uid": "P8E80F9AEF21F6940"
         },
         "definition": "",
-        "hide": 0,
         "includeAll": true,
         "label": "Container",
         "multi": true,
@@ -307,20 +292,58 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": [
+            "$__all"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "includeAll": true,
+        "label": "Level",
+        "multi": true,
+        "name": "level",
+        "options": [
+          {
+            "selected": false,
+            "text": "error",
+            "value": "error"
+          },
+          {
+            "selected": false,
+            "text": "warning",
+            "value": "warning"
+          },
+          {
+            "selected": false,
+            "text": "info",
+            "value": "info"
+          },
+          {
+            "selected": false,
+            "text": "debug",
+            "value": "debug"
+          },
+          {
+            "selected": false,
+            "text": "trace",
+            "value": "trace"
+          }
+        ],
+        "query": "error, warning, info, debug, trace",
+        "type": "custom"
       },
       {
         "current": {
-          "selected": false,
           "text": "",
           "value": ""
         },
-        "hide": 0,
         "label": "Line Search",
         "name": "line_search",
         "options": [
@@ -331,7 +354,6 @@
           }
         ],
         "query": "",
-        "skipUrlSync": false,
         "type": "textbox"
       }
     ]

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1360,6 +1360,15 @@ promtail-logs:
         basic_auth:
           username: promtail-logs
           password_file: /etc/promtail/secrets/password
+    snippets:
+      pipelineStages:
+        - cri: {}
+        - drop:
+            expression: "(DEBUG|debug|Debug)"
+            drop_counter_reason: "debug message"
+        - drop:
+            expression: "(TRACE|trace|Trace)"
+            drop_counter_reason: "trace message"
 
   extraVolumeMounts:
     - name: loki-gateway-password

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1363,12 +1363,43 @@ promtail-logs:
     snippets:
       pipelineStages:
         - cri: {}
+
+        - regex:
+            expression: '(?P<level>ERROR|error|Error|WARN|warn|Warn|WARNING|warning|Warning|INFO|info|Info|DEBUG|debug|Debug|TRACE|trace|Trace)'
+        - labels:
+            level:
+
+        - replace:
+            expression: "(ERROR|Error)"
+            source: "level"
+            replace: "error"
+        - replace:
+            expression: "(WARN|Warn|WARNING|Warning)"
+            source: "level"
+            replace: "warning"
+        - replace:
+            expression: "(INFO|Info)"
+            source: "level"
+            replace: "info"
+        - replace:
+            expression: "(DEBUG|Debug)"
+            source: "level"
+            replace: "debug"
+        - replace:
+            expression: "(TRACE|Trace)"
+            source: "level"
+            replace: "trace"
+        - labels:
+            level:
+
         - drop:
-            expression: "(DEBUG|debug|Debug)"
-            drop_counter_reason: "debug message"
+            source: "level"
+            value: "debug"
+            drop_counter_reason: "debug level"
         - drop:
-            expression: "(TRACE|trace|Trace)"
-            drop_counter_reason: "trace message"
+            source: "level"
+            value: "trace"
+            drop_counter_reason: "trace level"
 
   extraVolumeMounts:
     - name: loki-gateway-password


### PR DESCRIPTION
Due to the amount of storage that debug and trace logs take up they are filtered out by promtail to not be stored persistently into loki.

With the switch to labels for the log level I've also included them in the grafana dashboard as a filter.