### PR TITLE
fix: allow to add users if the auth secret already exists

### DIFF
--- a/charts/loki-gateway/templates/secret-auth.yaml
+++ b/charts/loki-gateway/templates/secret-auth.yaml
@@ -1,28 +1,36 @@
 {{- if ($.Values.auth).enabled }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-auth" (include "accelleran.common.fullname" (dict "top" $))) -}}
-{{- if not $existingSecret }}
 {{-
   include
     "accelleran.common.secret"
     (fromYaml (include "accelleran.loki-gateway.secretAuth.args" $))
 -}}
 {{- end }}
-{{- end }}
 
 
 {{- define "accelleran.loki-gateway.secretAuth.args" -}}
 {{- $ := . -}}
 
+{{- $name := printf "%s-auth" (include "accelleran.common.fullname" (dict "top" $)) -}}
+
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name -}}
+
 {{- $users := dict -}}
 {{- range $index, $user := $.Values.auth.users -}}
 {{- $username := $user.username | required (printf "A username is required when auth is enabled in loki-gateway (auth.users[%d].username)" $index) -}}
-{{- $password := $user.password | default (randAlphaNum 48) -}}
+{{- $existingPassword := get ($existingSecret.data) $username | b64dec -}}
+{{- $userPassword := $user.password -}}
+{{- $password := "" -}}
+{{- if $.Values.auth.overwriteExistingPasswords -}}
+{{- $password = $userPassword | default $existingPassword | default (randAlphaNum 48) -}}
+{{- else -}}
+{{- $password = $existingPassword | default $userPassword | default (randAlphaNum 48) -}}
+{{- end -}}
 {{- $_ := set $users $username $password -}}
 {{- end -}}
 
 top: {{ $ | toYaml | nindent 2 }}
 
-name: "{{ include "accelleran.common.fullname" (dict "top" $) }}-auth"
+name: {{ $name | quote }}
 
 {{- if ($.Values.auth).preventSecretUninstall }}
 annotations:

--- a/charts/loki-gateway/values.yaml
+++ b/charts/loki-gateway/values.yaml
@@ -27,6 +27,7 @@ clusterDomain: cluster.local
 auth:
   enabled: false
   preventSecretUninstall: true
+  overwriteExistingPasswords: false
   users: []
     # - username: "user"
     #   password: "pass"


### PR DESCRIPTION
Loki-gateway's auth secret was left untouched if it already existed. But this meant that it would not be possible for new users to be added. 