### PR TITLE
feat: allow to inject pod annotations via template args

### DIFF
--- a/charts/common/templates/_annotations.tpl
+++ b/charts/common/templates/_annotations.tpl
@@ -12,3 +12,19 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "accelleran.common.annotations.pod" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to common pod annotations" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{- $annotations := get . "podAnnotations" -}}
+
+{{- if $annotations -}}
+{{- $annotations | toYaml }}
+{{- else -}}
+{{- with $values.podAnnotations -}}
+{{ tpl (toYaml .) $ }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/common/templates/_pod.tpl
+++ b/charts/common/templates/_pod.tpl
@@ -39,9 +39,9 @@ metadata:
     {{- with $values.podLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $values.podAnnotations }}
+  {{- with (include "accelleran.common.annotations.pod" .) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
   {{- with $restartPolicy }}


### PR DESCRIPTION
Allow to inject pod annotations through the template args. This would for example allow to set checksum annotations for rollout of config changes.