### PR TITLE
feat: automatically update pods on config changes

### DIFF
--- a/charts/loki-gateway/templates/configmap.yaml
+++ b/charts/loki-gateway/templates/configmap.yaml
@@ -11,131 +11,137 @@
 top: {{ $ | toYaml | nindent 2 }}
 
 name: {{ include "accelleran.common.fullname" (dict "top" $) }}-config
-data:
-  nginx.conf: |+
-    worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
-    pid        /tmp/nginx.pid;
-    worker_rlimit_nofile 8192;
+data: {{ include "accelleran.loki-gateway.configMap.args.data" $ | nindent 2 }}
+{{- end -}}
 
-    events {
-      worker_connections  4096;  ## Default: 1024
-    }
 
-    http {
-      client_body_temp_path /tmp/client_temp;
-      proxy_temp_path       /tmp/proxy_temp_path;
-      fastcgi_temp_path     /tmp/fastcgi_temp;
-      uwsgi_temp_path       /tmp/uwsgi_temp;
-      scgi_temp_path        /tmp/scgi_temp;
+{{- define "accelleran.loki-gateway.configMap.args.data" -}}
+{{- $ := . -}}
 
-      sendfile     on;
-      tcp_nopush   on;
-      {{- if .Values.resolver }}
-      resolver {{ .Values.resolver }};
-      {{- else }}
-      resolver {{ .Values.dnsService }}.{{ .Values.dnsNamespace }}.svc.{{ .Values.clusterDomain }}.;
+nginx.conf: |+
+  worker_processes  5;  ## Default: 1
+  error_log  /dev/stderr;
+  pid        /tmp/nginx.pid;
+  worker_rlimit_nofile 8192;
+
+  events {
+    worker_connections  4096;  ## Default: 1024
+  }
+
+  http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    sendfile     on;
+    tcp_nopush   on;
+    {{- if .Values.resolver }}
+    resolver {{ .Values.resolver }};
+    {{- else }}
+    resolver {{ .Values.dnsService }}.{{ .Values.dnsNamespace }}.svc.{{ .Values.clusterDomain }}.;
+    {{- end }}
+
+    {{- if (.Values.auth).enabled }}
+    map $remote_user $loki_org_id {
+      {{- range $index, $user := .Values.auth.users }}
+      {{ $user.username }} {{ $user.organization | required (printf "An organization is required when auth is enabled in loki-gateway (auth.users[%d].organization)" $index) }};
       {{- end }}
+    }
+    {{- end }}
+
+    server {
+      listen     8080;
 
       {{- if (.Values.auth).enabled }}
-      map $remote_user $loki_org_id {
-        {{- range $index, $user := .Values.auth.users }}
-        {{ $user.username }} {{ $user.organization | required (printf "An organization is required when auth is enabled in loki-gateway (auth.users[%d].organization)" $index) }};
-        {{- end }}
-      }
+      auth_basic           "Loki";
+      auth_basic_user_file /etc/nginx/secrets/.htpasswd;
       {{- end }}
 
-      server {
-        listen     8080;
+      location = / {
+        return 200 'OK';
+        auth_basic off;
+      }
 
+      location = /api/prom/push {
+        proxy_pass       http://{{ .Release.Name }}-loki-distributor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
         {{- if (.Values.auth).enabled }}
-        auth_basic           "Loki";
-        auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+        proxy_set_header X-Scope-OrgID $loki_org_id;
         {{- end }}
+      }
 
-        location = / {
-          return 200 'OK';
-          auth_basic off;
-        }
+      location = /api/prom/tail {
+        proxy_pass       http://{{ .Release.Name }}-loki-querier.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+      }
 
-        location = /api/prom/push {
-          proxy_pass       http://{{ .Release.Name }}-loki-distributor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
+      # Ruler
+      location ~ /prometheus/api/v1/alerts.* {
+        proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
+      location ~ /prometheus/api/v1/rules.* {
+        proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
+      location ~ /api/prom/rules.* {
+        proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
+      location ~ /api/prom/alerts.* {
+        proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
 
-        location = /api/prom/tail {
-          proxy_pass       http://{{ .Release.Name }}-loki-querier.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-          proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-        }
+      location ~ /api/prom/.* {
+        proxy_pass       http://{{ .Release.Name }}-loki-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
 
-        # Ruler
-        location ~ /prometheus/api/v1/alerts.* {
-          proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
-        location ~ /prometheus/api/v1/rules.* {
-          proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
-        location ~ /api/prom/rules.* {
-          proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
-        location ~ /api/prom/alerts.* {
-          proxy_pass       http://{{ .Release.Name }}-loki-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
+      location = /loki/api/v1/push {
+        proxy_pass       http://{{ .Release.Name }}-loki-distributor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
 
-        location ~ /api/prom/.* {
-          proxy_pass       http://{{ .Release.Name }}-loki-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
+      location = /loki/api/v1/delete {
+        proxy_pass       http://{{ .Release.Name }}-loki-compactor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+      }
 
-        location = /loki/api/v1/push {
-          proxy_pass       http://{{ .Release.Name }}-loki-distributor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
+      location = /loki/api/v1/tail {
+        proxy_pass       http://{{ .Release.Name }}-loki-querier.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+      }
 
-        location = /loki/api/v1/delete {
-          proxy_pass       http://{{ .Release.Name }}-loki-compactor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
-
-        location = /loki/api/v1/tail {
-          proxy_pass       http://{{ .Release.Name }}-loki-querier.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-          proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-        }
-
-        location ~ /loki/api/.* {
-          proxy_pass       http://{{ .Release.Name }}-loki-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
-          {{- if (.Values.auth).enabled }}
-          proxy_set_header X-Scope-OrgID $loki_org_id;
-          {{- end }}
-        }
+      location ~ /loki/api/.* {
+        proxy_pass       http://{{ .Release.Name }}-loki-query-frontend.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3100$request_uri;
+        {{- if (.Values.auth).enabled }}
+        proxy_set_header X-Scope-OrgID $loki_org_id;
+        {{- end }}
       }
     }
+  }
 {{- end -}}

--- a/charts/loki-gateway/templates/deployment.yaml
+++ b/charts/loki-gateway/templates/deployment.yaml
@@ -10,6 +10,15 @@
 
 top: {{ $ | toYaml | nindent 2 }}
 
+podAnnotations:
+  {{- with $.Values.podAnnotations }}
+  {{ . | toYaml | nindent 2 }}
+  {{- end }}
+  checksum/config: {{ include "accelleran.loki-gateway.configMap.args.data" $ | sha256sum | quote }}
+  {{- if ($.Values.auth).enabled }}
+  checksum/auth: {{ include "accelleran.loki-gateway.secretAuth.args.stringData" $ | sha256sum | quote }}
+  {{- end }}
+
 volumeMounts:
   - name: tmp
     mountPath: /tmp

--- a/charts/loki-gateway/templates/secret-auth.yaml
+++ b/charts/loki-gateway/templates/secret-auth.yaml
@@ -10,9 +10,28 @@
 {{- define "accelleran.loki-gateway.secretAuth.args" -}}
 {{- $ := . -}}
 
-{{- $name := printf "%s-auth" (include "accelleran.common.fullname" (dict "top" $)) -}}
+top: {{ $ | toYaml | nindent 2 }}
 
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name -}}
+name: {{ printf "%s-auth" (include "accelleran.common.fullname" (dict "top" $)) | quote }}
+
+{{- if ($.Values.auth).preventSecretUninstall }}
+annotations:
+  {{- with $.Values.annotations }}
+  {{ . | toYaml | nindent 2 }}
+  {{- end }}
+  helm.sh/resource-policy: "keep"
+{{- end }}
+
+stringData: {{ include "accelleran.loki-gateway.secretAuth.args.stringData" $ | nindent 2 }}
+{{- end -}}
+
+
+{{- define "accelleran.loki-gateway.secretAuth.args.stringData" -}}
+{{- $ := . -}}
+
+{{- $secretName := printf "%s-auth" (include "accelleran.common.fullname" (dict "top" $)) -}}
+
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 
 {{- $users := dict -}}
 {{- range $index, $user := $.Values.auth.users -}}
@@ -28,25 +47,12 @@
 {{- $_ := set $users $username $password -}}
 {{- end -}}
 
-top: {{ $ | toYaml | nindent 2 }}
-
-name: {{ $name | quote }}
-
-{{- if ($.Values.auth).preventSecretUninstall }}
-annotations:
-  {{- with $.Values.annotations }}
-  {{ . | toYaml | nindent 2 }}
-  {{- end }}
-  helm.sh/resource-policy: "keep"
-{{- end }}
-
-stringData:
-  htpasswd: |-
-    {{- range $username, $password := $users }}
-    {{ htpasswd $username $password }}
-    {{- end }}
-
+htpasswd: |-
   {{- range $username, $password := $users }}
-  {{ $username }}: {{ $password | quote }}
+  {{ htpasswd $username $password }}
   {{- end }}
+
+{{- range $username, $password := $users }}
+{{ $username }}: {{ $password | quote }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
Rolls out the loki-gateway deployment automatically when config changes.

To achieve this a checksum of the configmap and secret data is added to the pod annotations. Hence the data is put in a template to be able to call it from both the secret/configmap and deployment args.

Note that when a password is left emtpy (without the password for that user already existing in the secret), that there will be a random string generated. This will happen twice, once for the actual data and once for the checksum calculation. Thus we would end up with a checksum different than the actual data of the secret. After a first upgrade a restart will thus always happen. After that, the password from the existing secret will be retrieved though, resulting in the correct checksum in the pod annotations.

Todo:
- [x] Merge #742 (PR is based on top of this)
- [x] Merge #743
- [x] Create new common chart release (#747)
- [x] Wait for renovate to automerge the common release into dependent charts (including loki-gateway) (#750)
- [X] Rebase this PR