### PR TITLE
fix: add fsgroup for netconf sysrepo volume mount

### DIFF
--- a/charts/cell-wrapper/values.yaml
+++ b/charts/cell-wrapper/values.yaml
@@ -264,6 +264,9 @@ netconf:
   extraLabels: {}
   annotations: {}
 
+  podSecurityContext:
+    fsGroup: 1000
+
   persistence:
     - name: sysrepo
       mountPath: "/workdir/sysrepo"

--- a/charts/cu-cp/values.yaml
+++ b/charts/cu-cp/values.yaml
@@ -122,6 +122,9 @@ netconf:
     initialDelaySeconds: 15
     periodSeconds: 30
 
+  podSecurityContext:
+    fsGroup: 1000
+
   persistence:
     - name: sysrepo
       mountPath: "/workdir/sysrepo"

--- a/charts/cu-up/values.yaml
+++ b/charts/cu-up/values.yaml
@@ -121,6 +121,9 @@ netconf:
     initialDelaySeconds: 15
     periodSeconds: 30
 
+  podSecurityContext:
+    fsGroup: 1000
+
   persistence:
     - name: sysrepo
       mountPath: "/workdir/sysrepo"


### PR DESCRIPTION
With some CSI drivers it's currently possible that the netconf server won't start:

```
[ERR] Creating directory "/workdir/sysrepo/yang" failed (Permission denied).
sysrepoctl error: Failed to connect (System function call failed)
```

To fix this, the `fsGroup` is set so the correct permissions are applied for a volume.