### PR TITLE
fix: remove metrics publishing to kafka

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -301,12 +301,12 @@ telemetry-collector:
             url: "{{ $.Release.Name }}-nats.{{ $.Release.Namespace }}:4222"
             subjects: "*.5G_MEAS_INFO.*.*.*.*"
         publishers:
-          kafkaPublisher:
-            topic: "accelleran.drax.5g.ric.o1.ves"
-        influxPublisher:
-          defaultBucket: "meas5g"
-          buckets:
-            RrcMeasurementReport: "rrc_measurements"
+          #kafkaPublisher:
+          #  topic: "accelleran.drax.5g.ric.o1.ves"
+          influxPublisher:
+            defaultBucket: "meas5g"
+            buckets:
+              RrcMeasurementReport: "rrc_measurements"
       - name: "pm_counters"
         component: "cu"
         vendor: "accelleran"
@@ -316,8 +316,8 @@ telemetry-collector:
             url: "{{ $.Release.Name }}-nats.{{ $.Release.Namespace }}:4222"
             subjects: "*.CUCP_COUNTERS_INFO,*.CUUP_COUNTERS_INFO"
         publishers:
-          kafkaPublisher:
-            topic: "accelleran.drax.5g.ric.o1.ves"
+          #kafkaPublisher:
+          #  topic: "accelleran.drax.5g.ric.o1.ves"
           influxPublisher:
             defaultBucket: "default_performance_metrics"
             buckets:
@@ -374,8 +374,8 @@ telemetry-collector:
           udpConsumer:
             port: "55555"
         publishers:
-          kafkaPublisher:
-            topic: "accelleran.drax.5g.ric.o1.ves"
+          #kafkaPublisher:
+          #  topic: "accelleran.drax.5g.ric.o1.ves"
           influxPublisher:
             defaultBucket: "acc_du"
             buckets:

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -301,8 +301,8 @@ telemetry-collector:
             url: "{{ $.Release.Name }}-nats.{{ $.Release.Namespace }}:4222"
             subjects: "*.5G_MEAS_INFO.*.*.*.*"
         publishers:
-          #kafkaPublisher:
-          #  topic: "accelleran.drax.5g.ric.o1.ves"
+          # kafkaPublisher:
+          #   topic: "accelleran.drax.5g.ric.o1.ves"
           influxPublisher:
             defaultBucket: "meas5g"
             buckets:
@@ -316,8 +316,8 @@ telemetry-collector:
             url: "{{ $.Release.Name }}-nats.{{ $.Release.Namespace }}:4222"
             subjects: "*.CUCP_COUNTERS_INFO,*.CUUP_COUNTERS_INFO"
         publishers:
-          #kafkaPublisher:
-          #  topic: "accelleran.drax.5g.ric.o1.ves"
+          # kafkaPublisher:
+          #   topic: "accelleran.drax.5g.ric.o1.ves"
           influxPublisher:
             defaultBucket: "default_performance_metrics"
             buckets:
@@ -374,8 +374,8 @@ telemetry-collector:
           udpConsumer:
             port: "55555"
         publishers:
-          #kafkaPublisher:
-          #  topic: "accelleran.drax.5g.ric.o1.ves"
+          # kafkaPublisher:
+          #   topic: "accelleran.drax.5g.ric.o1.ves"
           influxPublisher:
             defaultBucket: "acc_du"
             buckets:

--- a/charts/telemetry-collector/values.yaml
+++ b/charts/telemetry-collector/values.yaml
@@ -74,12 +74,12 @@ config:
           url: ""
         subjects: "*.5G_MEAS_INFO.*.*.*.*"
       publishers:
-        kafkaPublisher:
-          topic: "accelleran.drax.5g.ric.o1.ves"
-      influxPublisher:
-        defaultBucket: "meas5g"
-        buckets:
-          RrcMeasurementReport: "rrc_measurements"
+        #kafkaPublisher:
+        #  topic: "accelleran.drax.5g.ric.o1.ves"
+        influxPublisher:
+          defaultBucket: "meas5g"
+          buckets:
+            RrcMeasurementReport: "rrc_measurements"
     - name: "pm_counters"
       component: "cu"
       vendor: "accelleran"
@@ -89,8 +89,8 @@ config:
           url: ""
           subjects: "*.CUCP_COUNTERS_INFO,*.CUUP_COUNTERS_INFO"
       publishers:
-        kafkaPublisher:
-          topic: "accelleran.drax.5g.ric.o1.ves"
+        #kafkaPublisher:
+        #  topic: "accelleran.drax.5g.ric.o1.ves"
         influxPublisher:
           defaultBucket: "counters5g"
           buckets:
@@ -147,8 +147,8 @@ config:
         udpConsumer:
           port: "55555"
       publishers:
-        kafkaPublisher:
-          topic: "accelleran.drax.5g.ric.o1.ves"
+        #kafkaPublisher:
+        #  topic: "accelleran.drax.5g.ric.o1.ves"
         influxPublisher:
           defaultBucket: "acc_du"
           buckets:

--- a/charts/telemetry-collector/values.yaml
+++ b/charts/telemetry-collector/values.yaml
@@ -74,8 +74,8 @@ config:
           url: ""
         subjects: "*.5G_MEAS_INFO.*.*.*.*"
       publishers:
-        #kafkaPublisher:
-        #  topic: "accelleran.drax.5g.ric.o1.ves"
+        # kafkaPublisher:
+        #   topic: "accelleran.drax.5g.ric.o1.ves"
         influxPublisher:
           defaultBucket: "meas5g"
           buckets:
@@ -89,8 +89,8 @@ config:
           url: ""
           subjects: "*.CUCP_COUNTERS_INFO,*.CUUP_COUNTERS_INFO"
       publishers:
-        #kafkaPublisher:
-        #  topic: "accelleran.drax.5g.ric.o1.ves"
+        # kafkaPublisher:
+        #   topic: "accelleran.drax.5g.ric.o1.ves"
         influxPublisher:
           defaultBucket: "counters5g"
           buckets:
@@ -147,8 +147,8 @@ config:
         udpConsumer:
           port: "55555"
       publishers:
-        #kafkaPublisher:
-        #  topic: "accelleran.drax.5g.ric.o1.ves"
+        # kafkaPublisher:
+        #   topic: "accelleran.drax.5g.ric.o1.ves"
         influxPublisher:
           defaultBucket: "acc_du"
           buckets:


### PR DESCRIPTION
Stops the publishing to Kafka from the telemetry collector that causes the disk pressure issue. Seems like there was an indentation error as well for the influxPublishers