### PR TITLE
feat: allow to set the persistent log level per pod

### DIFF
--- a/charts/cell-wrapper/values.yaml
+++ b/charts/cell-wrapper/values.yaml
@@ -5,6 +5,8 @@ global:
   imagePullSecrets:
     - name: accelleran-secret
 
+  persistentLogLevel: info
+
   nodeSelector: {}
 
 

--- a/charts/cu-cp/values.yaml
+++ b/charts/cu-cp/values.yaml
@@ -6,6 +6,8 @@ global:
   imagePullSecrets:
     - name: accelleran-secret
 
+  persistentLogLevel: info
+
   nodeSelector: {}
 
 

--- a/charts/cu-up/values.yaml
+++ b/charts/cu-up/values.yaml
@@ -6,6 +6,8 @@ global:
   imagePullSecrets:
     - name: accelleran-secret
 
+  persistentLogLevel: info
+
   nodeSelector: {}
 
 

--- a/charts/drax/charts/config-api/values.yaml
+++ b/charts/drax/charts/config-api/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 drax:
   role: ric
@@ -19,9 +28,6 @@ image:
   repository: accelleran/config-api
   pullPolicy: IfNotPresent
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: false

--- a/charts/drax/charts/dashboard/values.yaml
+++ b/charts/drax/charts/dashboard/values.yaml
@@ -2,6 +2,16 @@ global:
   enable4G: false
   enable5G: true
 
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
+
 bootstrap:
   create: true
   name: ""
@@ -62,9 +72,6 @@ image:
   repository: accelleran/dash-front-back-end
   pullPolicy: IfNotPresent
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: false

--- a/charts/drax/charts/e2-t/values.yaml
+++ b/charts/drax/charts/e2-t/values.yaml
@@ -6,6 +6,8 @@ global:
   imagePullSecrets:
     - name: accelleran-secret
 
+  persistentLogLevel: info
+
   nodeSelector: {}
 
 # Number of supported components

--- a/charts/drax/charts/golang-nkafka/values.yaml
+++ b/charts/drax/charts/golang-nkafka/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 mode: "5g"
 
@@ -60,9 +69,6 @@ image:
   repository: accelleran/golang-nkafka-5g
   pullPolicy: IfNotPresent
   tag: "1.3.9_cu-6.0.3-nostradamus_cw-5.0.3"
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: true

--- a/charts/drax/charts/network-state-monitor/values.yaml
+++ b/charts/drax/charts/network-state-monitor/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 drax:
   role: ric
@@ -30,9 +39,6 @@ image:
   pullPolicy: IfNotPresent
   # Override the image tag, which defaults to the Chart's AppVersion
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: false

--- a/charts/drax/charts/pm-counters/values.yaml
+++ b/charts/drax/charts/pm-counters/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 drax:
   role: "xapp"
@@ -36,9 +45,6 @@ image:
   repository: accelleran/acc-fiveg-pmcounters
   pullPolicy: IfNotPresent
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: false

--- a/charts/drax/charts/service-monitor/values.yaml
+++ b/charts/drax/charts/service-monitor/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 # Namespaces to monitor, comma "," seperated
 monitoredNamespaces: "{{ .Release.Namespace }}"
@@ -13,8 +22,6 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: true

--- a/charts/drax/charts/service-orchestrator/values.yaml
+++ b/charts/drax/charts/service-orchestrator/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 kubeIp: "10.55.1.2"
 default5gVersion: "9"
@@ -29,9 +38,6 @@ image:
   repository: accelleran/service-orchestrator
   pullPolicy: IfNotPresent
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: true

--- a/charts/drax/configuration/grafana/dashboards/loki-log-dashboard.json
+++ b/charts/drax/configuration/grafana/dashboards/loki-log-dashboard.json
@@ -334,9 +334,14 @@
             "selected": false,
             "text": "trace",
             "value": "trace"
+          },
+          {
+            "selected": false,
+            "text": "unkown",
+            "value": "unknown"
           }
         ],
-        "query": "error, warning, info, debug, trace",
+        "query": "error, warning, info, debug, trace, unknown",
         "type": "custom"
       },
       {

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1391,7 +1391,7 @@ promtail-logs:
 
         - template:
             source: "level"
-            template: "{{ .Value | TrimSpace | ToLower }}"
+            template: "{{ .Value | TrimSpace | default \"unknown\" | ToLower }}"
         - replace:
             source: "level"
             expression: "^(warn)$"

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1364,6 +1364,13 @@ promtail-logs:
           username: promtail-logs
           password_file: /etc/promtail/secrets/password
     snippets:
+      extraRelabelConfigs:
+        # set drax.accelleran.com/persistent-log-level=info to store info and up, default warning
+        - source_labels:
+            - __meta_kubernetes_pod_label_drax_accelleran_com_persistent_log_level
+          regex: ^;*([^;]+)(;.*)?$
+          action: replace
+          target_label: persistent_level
       pipelineStages:
         - cri: {}
 
@@ -1372,37 +1379,56 @@ promtail-logs:
         - labels:
             level:
 
+        - template:
+            source: "persistent_level"
+            template: "{{ .Value | TrimSpace | default \"warning\" | ToLower }}"
         - replace:
-            expression: "(ERROR|Error)"
-            source: "level"
-            replace: "error"
-        - replace:
-            expression: "(WARN|Warn|WARNING|Warning)"
-            source: "level"
+            source: "persistent_level"
+            expression: "^(warn)$"
             replace: "warning"
-        - replace:
-            expression: "(INFO|Info)"
+        - labels:
+            persistent_level:
+
+        - template:
             source: "level"
-            replace: "info"
+            template: "{{ .Value | TrimSpace | ToLower }}"
         - replace:
-            expression: "(DEBUG|Debug)"
             source: "level"
-            replace: "debug"
-        - replace:
-            expression: "(TRACE|Trace)"
-            source: "level"
-            replace: "trace"
+            expression: "^(warn)$"
+            replace: "warning"
         - labels:
             level:
 
         - drop:
-            source: "level"
-            value: "debug"
+            source:
+              - "level"
+              - "persistent_level"
+            expression: "(trace);(debug|info|warning|error|none)"
+            drop_counter_reason: "trace level"
+        - drop:
+            source:
+              - "level"
+              - "persistent_level"
+            expression: "(debug);(info|warning|error|none)"
             drop_counter_reason: "debug level"
         - drop:
-            source: "level"
-            value: "trace"
-            drop_counter_reason: "trace level"
+            source:
+              - "level"
+              - "persistent_level"
+            expression: "(info);(warning|error|none)"
+            drop_counter_reason: "info level"
+        - drop:
+            source:
+              - "level"
+              - "persistent_level"
+            expression: "(warning);(error|none)"
+            drop_counter_reason: "warning level"
+        - drop:
+            source:
+              - "level"
+              - "persistent_level"
+            expression: "(error);(none)"
+            drop_counter_reason: "error level"
 
   extraVolumeMounts:
     - name: loki-gateway-password

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -34,6 +34,8 @@ global:
     enabled: true
     secretName: "accelleran-license"
 
+  persistentLogLevel: info
+
   nodeSelector: {}
 
 bootstrap:
@@ -936,6 +938,8 @@ grafana:
 
 loki-gateway:
   # enabled: true
+
+  persistentLogLevel: warning
 
   auth:
     enabled: true

--- a/charts/du-metrics-server/values.yaml
+++ b/charts/du-metrics-server/values.yaml
@@ -1,3 +1,14 @@
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
+
 bootstrap:
   create: true
   name: ""
@@ -28,9 +39,6 @@ du-metrics-server:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
-
-  imagePullSecrets:
-    - name: accelleran-secret
 
   accelleranLicense:
     enabled: false

--- a/charts/loki-deleter/values.yaml
+++ b/charts/loki-deleter/values.yaml
@@ -1,3 +1,14 @@
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -10,9 +21,6 @@ image:
 
 accelleranLicense:
   enabled: false
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 config:
   loki:

--- a/charts/loki-gateway/values.yaml
+++ b/charts/loki-gateway/values.yaml
@@ -1,3 +1,11 @@
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  persistentLogLevel: warning
+
+  nodeSelector: {}
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/telemetry-collector/values.yaml
+++ b/charts/telemetry-collector/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 nameOverride: ""
 fullnameOverride: ""
@@ -9,9 +18,6 @@ image:
   repository: accelleran/telemetry-collector
   pullPolicy: IfNotPresent
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: true

--- a/charts/xapp-anr/values.yaml
+++ b/charts/xapp-anr/values.yaml
@@ -1,4 +1,13 @@
-global: {}
+global:
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets:
+    - name: accelleran-secret
+
+  persistentLogLevel: info
+
+  nodeSelector: {}
 
 nameOverride: ""
 fullnameOverride: ""
@@ -17,9 +26,6 @@ image:
   repository: accelleran/xapp-anr
   pullPolicy: IfNotPresent
   tag: ""
-
-imagePullSecrets:
-  - name: accelleran-secret
 
 accelleranLicense:
   enabled: true


### PR DESCRIPTION
This PR allows to control per pod the level for logs that should be persisted. The default is `warning` (mainly for third-party pods of drax or external pods like the kubernetes api server).

Note that I've set loki-gateway also to warning. We maintain the helm chart ourselves with the common chart templates, but it's running nginx.

TODO:

- [x] #788 
- [x] Release new common chart (#791)
- [x] Let renovate bump the common chart for the others (#792)
- [x] Rebase this PR