### PR TITLE
fix: filter only notify events for notifications

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1462,7 +1462,16 @@ promtail-notifications:
                   stndDefinedNamespace: event.commonEventHeader.stndDefinedNamespace
                   version: event.commonEventHeader.version
                   timeZoneOffset: event.commonEventHeader.timeZoneOffset
+                  notificationType: event.stndDefinedFields.data.notificationType
                   vesEventListenerVersion: event.commonEventHeader.vesEventListenerVersion
+            - regex:
+               expression: '^(?P<keep>notifyEvent)$'
+               source: notificationType
+            - labels:
+               keep: '{{.keep}}'
+            - drop:
+               source: keep
+               value: ''
             - labels:
                 domain:
                 eventId:

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1462,13 +1462,14 @@ promtail-notifications:
                   stndDefinedNamespace: event.commonEventHeader.stndDefinedNamespace
                   version: event.commonEventHeader.version
                   timeZoneOffset: event.commonEventHeader.timeZoneOffset
-                  notificationType: event.stndDefinedFields.data.notificationType
                   vesEventListenerVersion: event.commonEventHeader.vesEventListenerVersion
+                  notificationType: event.stndDefinedFields.data.notificationType
+                drop_malformed: true
             - regex:
                expression: '^(?P<keep>notifyEvent)$'
                source: notificationType
             - labels:
-               keep: '{{.keep}}'
+               keep:
             - drop:
                source: keep
                value: ''


### PR DESCRIPTION
This PR configures the notification promtail job to drop any messages apart from the ones where notificationType="notifyEvent"