### PR TITLE
feat: allow to override license image suffix

### DIFF
--- a/charts/common/templates/_container.tpl
+++ b/charts/common/templates/_container.tpl
@@ -67,7 +67,17 @@ volumeMounts:
 {{- $imageTag := include "accelleran.common.appVersion" . -}}
 
 {{- if eq (include "accelleran.common.drax.license.enabled" .) "true" -}}
-{{- $imageRepository = (printf "%s-license" $imageRepository) -}}
+
+{{- $imageSuffix := "" -}}
+{{- if ne ($values.accelleranLicense).imageSuffix nil -}}
+{{- $imageSuffix = ($values.accelleranLicense).imageSuffix -}}
+{{- else if ne (($.Values.global).accelleranLicense).imageSuffix nil -}}
+{{- $imageSuffix = (($.Values.global).accelleranLicense).imageSuffix -}}
+{{- else -}}
+{{- $imageSuffix = "-license" -}}
+{{- end -}}
+
+{{- $imageRepository = (printf "%s%s" $imageRepository $imageSuffix) -}}
 {{- end -}}
 
 image: {{ printf "%s:%s" $imageRepository $imageTag | quote }}


### PR DESCRIPTION
Allows for #871 to be merged as the CU doesn't have a `-license` suffix in the image repositories.