### PR TITLE
ci: add mergeability workflow

### DIFF
--- a/.github/workflows/mergeability.yaml
+++ b/.github/workflows/mergeability.yaml
@@ -1,0 +1,17 @@
+name: Mergeability
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  check-main:
+    name: Check main
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: bennycode/stop-merging@a872a98c65e2388a0fcf2415c4a43f259bb338e7  # main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_BRANCH: 'main'
+          BYPASS_PREFIX: 'fix(mergeability): '


### PR DESCRIPTION
This is a PR to make the repository a little bit less error-prone.

This workflow will block all PRs until the checks on the last commit on the main branch have succeeded. This will prevent cases where release please hasn't run on a release commit/PR merge, which will mess up the next version PR proposal.

Next to the action, also the branch protection rules needed an update (as per the `stop-merging` action [docs](https://github.com/bennycode/stop-merging/blob/main/README.md)). Now a PR can only merged if all checks are okay and if the latest changes of the main branch are merged in.

An example PR that was messed up is #888 (for `1.0.6`), which includes also commit messages for the `1.0.1` release (the bump of the common charts to `0.3.5` for example).

