### PR TITLE
ci: block merging if main not completed or failed

### DIFF
--- a/.github/actions/block-merging/README.md
+++ b/.github/actions/block-merging/README.md
@@ -1,0 +1,14 @@
+# Block Merging
+
+This action checks whether all checks have successfully completed before allowing a merge.
+
+## Prerequisites
+
+Configure branch protection rules for the main branch:
+
+* Enable "Require status checks to pass before merging"
+* Enable "Require branches to be up to date before merging"
+
+## Bypassing
+
+The mergeability check can be bypassed by using the prefix `fix(mergeability): ` in the PR title.

--- a/.github/actions/block-merging/action.yml
+++ b/.github/actions/block-merging/action.yml
@@ -1,0 +1,82 @@
+name: Block Merge
+description: Block merging until the main branch is good to go
+inputs:
+  github_token:
+    description: Token to access github repo
+    required: true
+  branch:
+    description: Target branch to check
+    default: main
+  bypass_prefix:
+    description: Commit message prefix to bypass the check
+    default: "fix(mergeability): "
+runs:
+  using: "composite"
+  steps:
+    - name: Add Link to Description
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      env:
+        BRANCH: ${{ inputs.branch }}
+        BYPASS_PREFIX: ${{ inputs.bypass_prefix }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |-
+          const {owner,repo} = context.repo;
+          const branch = process.env.BRANCH;
+
+          const prTitle = process.env.PR_TITLE;
+          const bypassPrefix = process.env.BYPASS_PREFIX;
+
+          if (prTitle.startsWith(bypassPrefix)) {
+            console.log(`Merging is allowed as the PR title ("${prTitle}") matches the bypass prefix ("${bypassPrefix}")`);
+            process.exit(0);
+          }
+
+          const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+          const retry = async (fn, maxAttempts) => {
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
+              try {
+                return await fn();
+              } catch (err) {
+                console.error(`Error in attempt ${attempt}: ${err.message}`);
+                await sleep(5000);
+              }
+            }
+          };
+
+          const fetchCompletedChecks = async () => {
+            const checksResponse = await github.rest.checks.listForRef({
+              owner: owner,
+              repo: repo,
+              ref: `heads/${branch}`,
+            });
+            if (checksResponse.status != 200) {
+              throw new Error(`Checks for ${branch} couldn't be retrieved in attempt ${attempt}`);
+            }
+
+            const checks = checksResponse.data.check_runs;
+
+            for (const check of checks) {
+              if (check.status !== "completed") {
+                throw new Error(`Merging is blocked as the checks for ${branch} haven't completed yet`);
+              }
+            }
+
+            return checks;
+          };
+
+
+          const completedChecks = await retry(fetchCompletedChecks, Infinity);
+
+          for (const check of completedChecks) {
+            if (check.conclusion === "failure") {
+              core.setFailed(`Merging is blocked as the checks for ${branch} include a failure`);
+              process.exit(1);
+            }
+          }
+
+          console.log(`Merging is allowed as all checks for ${branch} have completed without failures`);
+          process.exit(0);

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -140,14 +140,14 @@ jobs:
           subnets=$(docker network inspect -f '{{range .IPAM.Config}}{{printf "%s\n" .Subnet}}{{end}}' kind)
           printf "subnets:\n%s\n" "${subnets}"
           ipv4_subnets=$(echo "$subnets" | grep -E '(([0-9]{1,3})\.){3}([0-9]{1,3})\/([0-9]|[1-2][0-9]|3[0-2])')
-          printf "ipv4_subnets:\n%s\n" "${ipv4_subnets}"
+          printf "ipv4_subnets=\n%s\n" "${ipv4_subnets}"
           subnet=$(echo "$ipv4_subnets" | head -n 1)
-          printf "subnet: '%s'\n" "${subnet}"
+          printf "subnet=%s\n" "${subnet}"
 
           net_ip=$(echo "$subnet" | cut -d/ -f1)
-          printf "net_ip: '%s'\n" "${net_ip}"
+          printf "net_ip=%s\n" "${net_ip}"
           cidr=$(echo "$subnet" | cut -d/ -f2)
-          printf "cidr: '%s'\n" "${cidr}"
+          printf "cidr=%s\n" "${cidr}"
           if [ $cidr -gt 24 ]; then
             echo "CIDR of $subnet needs to be 24 or smaller" 1>&2
             exit 1
@@ -155,7 +155,7 @@ jobs:
 
           net_ip_prefix=$(echo $net_ip | cut -d. -f 1-3)
           ip_range=$net_ip_prefix.200-$net_ip_prefix.250
-          printf "ip_range: '%s'\n" "${ip_range}"
+          printf "ip_range=%s\n" "${ip_range}"
 
           cat <<EOF | kubectl apply -f -
           apiVersion: metallb.io/v1beta1
@@ -215,6 +215,23 @@ jobs:
           --set=kafka.provisioning.useHelmHooks=false
           --set=global.deploymentId=testGithub
           "
+
+  # This is a work-around for a required check with matrix in the branch protection rules
+  status-charts:
+    name: Status Charts
+    needs:
+      - vars
+      - lint-charts
+      - test-charts
+    if: ${{ needs.vars.outputs.is_pull_request == 'true' && always() }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Successful checks
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing checks
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
 
   release-charts:
     name: Release Charts

--- a/.github/workflows/mergeability.yaml
+++ b/.github/workflows/mergeability.yaml
@@ -10,8 +10,15 @@ jobs:
     name: Check main
     runs-on: ubuntu-24.04
     steps:
-      - uses: bennycode/stop-merging@a872a98c65e2388a0fcf2415c4a43f259bb338e7  # main
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_BRANCH: 'main'
-          BYPASS_PREFIX: 'fix(mergeability): '
+          fetch-depth: 0
+          sparse-checkout: |
+            .github/actions/block-merging
+      - name: Block merging
+        uses: ./.github/actions/block-merging
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: 'main'
+          bypass_prefix: 'fix(mergeability): '


### PR DESCRIPTION
Fixes #890 which only looked at one of the workflows (to be completed and without failures) instead of all of them.