### PR TITLE
ci: increase ct timeouts

### DIFF
--- a/etc/ct.yaml
+++ b/etc/ct.yaml
@@ -6,5 +6,5 @@ lint-conf: "etc/lintconf.yaml"
 validate-chart-schema: true
 chart-yaml-schema: "etc/chart_schema.yaml"
 validate-maintainers: false
-helm-extra-args: --timeout 300s
-kubectl-timeout: 300s
+helm-extra-args: --timeout 450s
+kubectl-timeout: 450s


### PR DESCRIPTION
The drax chart is getting to the point where 5 minutes is resulting in flaky test results. Thus an increase to 7.5 minutes to reduce this.