### PR TITLE
ci: allow merge queues

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - releases/**
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mergeability.yaml
+++ b/.github/workflows/mergeability.yaml
@@ -2,8 +2,13 @@ name: Mergeability
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
-    branches: [main]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - main
   merge_group:
 
 jobs:

--- a/.github/workflows/mergeability.yaml
+++ b/.github/workflows/mergeability.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
+  merge_group:
 
 jobs:
   check-main:


### PR DESCRIPTION
This PR sets the `merge_group` event as a trigger to allow using merge queues.

When configuring them in the branch protection rules, we need to check `Require merge queue` and set the `Maximum pull requests to merge` to 1 (for release please).