### PR TITLE
fix: expose influxdb2 via nodeport

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1683,9 +1683,8 @@ influxdb2:
     size: 2Gi
 
   service:
-    type: ClusterIP
-    nodePorts:
-      http: ""
+    type: NodePort
+    nodePort: 31200
 
   resources:
     requests:


### PR DESCRIPTION
Until we have AAA in place, Ensar requested to expose influxdb2 via Nodeport. This was triggered by the influxDB2 documentation effort.