### PR TITLE
fix: remove rrCtrl from 5G Health Dashboard

### DIFF
--- a/charts/drax/configuration/grafana/dashboards/5g-health-dashboard.json
+++ b/charts/drax/configuration/grafana/dashboards/5g-health-dashboard.json
@@ -1328,71 +1328,6 @@
         "x": 6,
         "y": 12
       },
-      "id": 106,
-      "links": [],
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "first"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "expr": "sum(kube_pod_container_status_running{pod=~\".*rr-ctrl.*\"}) or kube_pod_container_status_running{pod=~\"kube-apiserver-.*\"}-1",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Number of supported CELLS",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 12
-      },
       "id": 108,
       "links": [],
       "options": {
@@ -1455,7 +1390,7 @@
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 12,
+        "x": 9,
         "y": 12
       },
       "id": 109,
@@ -1520,7 +1455,7 @@
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 15,
+        "x": 12,
         "y": 12
       },
       "id": 114,


### PR DESCRIPTION
PR #950 removes rrCtrl from the CU Helm charts. This PR removes rrCtrl from the 5G Health Dashboard.