### PR TITLE
fix: fix statefulset headless service

### DIFF
--- a/charts/common/templates/_statefulset.tpl
+++ b/charts/common/templates/_statefulset.tpl
@@ -60,6 +60,7 @@ values:
     enabled: true
     type: "ClusterIP"
     clusterIP: "None"
+    externalTrafficPolicy: null
 {{- end -}}
 
 


### PR DESCRIPTION
When an externally accessible service is used to target a statefulset then we cannot set externalTrafficPolicy.