### PR TITLE
chore: add script to update all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ To locally add all necessary repos:
 ./bin/add-repos
 ```
 
+During development it's also possible to test the chart locally.
+To add/update the local dependencies needed for that, the `bin/update-deps` script can be used.
+
+```sh
+./bin/update-deps
+```
+
+In case it's desired to also package up all helm charts and add them to the parent charts for testing,
+then a flag can be added to the script:
+
+```sh
+./bin/update-deps -l
+```
+
+This is for example handy during development on the `common` library chart.
+
 ## New charts
 
 A bit of setup is needed for release please when adding a new chart.

--- a/bin/update-deps
+++ b/bin/update-deps
@@ -8,7 +8,7 @@ function usage() {
     echo "Usage:"
     echo "update-deps"
     echo "    -h                Display usage."
-    echo "    -r                Skip downloading remote dependencies."
+    echo "    -R                Skip downloading remote dependencies."
     echo "    -l                Package local dependencies and copy them to the dependendents."
     echo "                      Skipped by default."
     echo ""

--- a/bin/update-deps
+++ b/bin/update-deps
@@ -118,7 +118,6 @@ while getopts ":hRl" opt; do
         ;;
     esac
 done
-shift $((OPTIND -1))
 
 if [ "${skip_remote_deps}" != true ] ; then
     update_remote_deps

--- a/bin/update-deps
+++ b/bin/update-deps
@@ -88,8 +88,7 @@ function package_and_copy_local_deps() {
     local dependent_charts=("${@:2}")
 
     printf "Packaging %s chart...\n" "$chart"
-    chart_package_stdout=$(helm package "$chart" --destination /tmp)
-    chart_tgz=$(echo "$chart_package_stdout" | cut -d':' -f2 | sed 's/ //g')
+    chart_tgz="$(helm package "$chart" --destination /tmp | sed 's/^Successfully packaged chart and saved it to: //')"
 
     printf "Copying %s chart tgz to dependents...\n\n" "$chart_tgz"
     for dependent_chart in "${dependent_charts[@]}" ; do

--- a/bin/update-deps
+++ b/bin/update-deps
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+BASE_DIR=$(dirname "$0")
+GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+CHARTS_ROOT="${GIT_ROOT}/charts"
+
+function usage() {
+    echo "Usage:"
+    echo "update-deps"
+    echo "    -h                Display usage."
+    echo "    -r                Skip downloading remote dependencies."
+    echo "    -l                Package local dependencies and copy them to the dependendents."
+    echo "                      Skipped by default."
+    echo ""
+    exit 0
+}
+
+function fatal() {
+    error "${@}"
+    exit 1
+}
+
+function error() {
+    echo "${1}" 1>&2
+}
+
+function update_remote_deps() {
+    printf "Updating local repo cache...\n\n"
+    helm repo update
+
+    for chart in "${CHARTS_ROOT}"/*/ "${CHARTS_ROOT}"/drax/charts/*/ ; do
+        printf "\nUpdating remote dependencies of %s...\n\n" "$chart"
+        helm dependency update "$chart" --skip-refresh
+    done
+}
+
+function update_local_deps() {
+    package_and_copy_local_deps "${CHARTS_ROOT}/common" \
+        "${CHARTS_ROOT}/cell-wrapper" \
+        "${CHARTS_ROOT}/cell-wrapper-config" \
+        "${CHARTS_ROOT}/cu-cp" \
+        "${CHARTS_ROOT}/cu-up" \
+        "${CHARTS_ROOT}/drax" \
+            "${CHARTS_ROOT}/drax/charts/config-api" \
+            "${CHARTS_ROOT}/drax/charts/dashboard" \
+            "${CHARTS_ROOT}/drax/charts/e2-t" \
+            "${CHARTS_ROOT}/drax/charts/golang-nkafka" \
+            "${CHARTS_ROOT}/drax/charts/network-state-monitor" \
+            "${CHARTS_ROOT}/drax/charts/pm-counters" \
+            "${CHARTS_ROOT}/drax/charts/service-monitor" \
+            "${CHARTS_ROOT}/drax/charts/service-orchestrator" \
+        "${CHARTS_ROOT}/du-metrics-server" \
+        "${CHARTS_ROOT}/loki-deleter" \
+        "${CHARTS_ROOT}/loki-gateway" \
+        "${CHARTS_ROOT}/telemetry-collector" \
+        "${CHARTS_ROOT}/xapp-anr"
+
+    package_and_copy_local_deps "${CHARTS_ROOT}/cell-wrapper" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/config-api" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/dashboard" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/e2-t" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/golang-nkafka" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/network-state-monitor" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/pm-counters" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/service-monitor" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/drax/charts/service-orchestrator" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/du-metrics-server" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/loki-deleter" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/loki-gateway" \
+        "${CHARTS_ROOT}/drax"
+    package_and_copy_local_deps "${CHARTS_ROOT}/telemetry-collector" \
+        "${CHARTS_ROOT}/drax"
+}
+
+function package_and_copy_local_deps() {
+    local chart="$1"
+    local dependent_charts=("${@:2}")
+
+    printf "Packaging %s chart...\n" "$chart"
+    chart_package_stdout=$(helm package "$chart" --destination /tmp)
+    chart_tgz=$(echo "$chart_package_stdout" | cut -d':' -f2 | sed 's/ //g')
+
+    printf "Copying %s chart tgz to dependents...\n\n" "$chart_tgz"
+    for dependent_chart in "${dependent_charts[@]}" ; do
+        cp "$chart_tgz" "$dependent_chart/charts/"
+    done
+}
+
+skip_remote_deps=false
+package_local_deps=false
+
+while getopts ":hRl" opt; do
+    case ${opt} in
+        h )
+            usage
+        ;;
+        R )
+            skip_remote_deps=true
+        ;;
+        l )
+            package_local_deps=true
+        ;;
+        \? )
+            fatal "Invalid Option: -${OPTARG}"
+        ;;
+        : )
+            fatal "Invalid option: ${OPTARG} requires an argument"
+        ;;
+    esac
+done
+shift $((OPTIND -1))
+
+if [ "${skip_remote_deps}" != true ] ; then
+    update_remote_deps
+fi
+
+if [ "${package_local_deps}" == true ] ; then
+    update_local_deps
+fi


### PR DESCRIPTION
This script allows to easily update all dependencies. It is for example handy during development in the common charts when you want to try it out in an application chart.

The local dependencies (the package and copy part) is hard-coded for simplicity reasons. First I was contemplating to discover all dependencies in the `Chart.yaml` files, but then we would also have to create a dependency tree etc. to walk over to ensure correct ordering of packaging and copying to the dependents...