### PR TITLE
fix!: use specific name args

### DIFF
--- a/charts/common/templates/_ingress.tpl
+++ b/charts/common/templates/_ingress.tpl
@@ -63,7 +63,7 @@ spec:
 {{- $ := get . "top" | required "The top context needs to be provided to common ingress name" -}}
 {{- $values := get . "values" | default $.Values -}}
 
-{{- get . "name" | default (get $values.ingress "name") | default (include "accelleran.common.fullname" .) -}}
+{{- get . "ingressName" | default (get $values.ingress "name") | default (include "accelleran.common.fullname" .) -}}
 {{- end -}}
 
 

--- a/charts/common/templates/_service.tpl
+++ b/charts/common/templates/_service.tpl
@@ -36,7 +36,7 @@ spec:
 {{- $ := get . "top" | required "The top context needs to be provided to common service name" -}}
 {{- $values := get . "values" | default $.Values -}}
 
-{{- get . "name" | default (get $values.service "name") | default (include "accelleran.common.fullname" .) -}}
+{{- get . "serviceName" | default (get $values.service "name") | default (include "accelleran.common.fullname" .) -}}
 {{- end -}}
 
 

--- a/charts/common/templates/_statefulset.tpl
+++ b/charts/common/templates/_statefulset.tpl
@@ -8,7 +8,7 @@
 {{- end -}}
 
 {{- $autoscaling := default (dict "enabled" false) (get $values "autoscaling") -}}
-{{- $serviceName := printf "%s-headless" (include "accelleran.common.service.name" .) -}}
+{{- $serviceName := printf "%s-headless" (include "accelleran.common.service.name" (mergeOverwrite (deepCopy .) (dict "serviceName" (get . "name")))) -}}
 
 {{- $volumeClaimTemplates := list -}}
 {{- range $persistence -}}
@@ -23,7 +23,7 @@
 {{- $volumeMounts = append $volumeMounts (dict "name" .name "mountPath" .mountPath) -}}
 {{- end -}}
 
-{{- include "accelleran.common.statefulset.headlessService" (mergeOverwrite (deepCopy .) (dict "name" $serviceName)) }}
+{{- include "accelleran.common.statefulset.headlessService" (mergeOverwrite (deepCopy .) (dict "serviceName" $serviceName)) }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Both service and ingress allowed to provide a template arg with the name. As ingress links to a service, providing this argument would override both the ingress and service name.
Therefore `name` is replaced with `serviceName` and `ingressName`.

Note that this is a breaking change in the common charts that will need changes in the netconf services to prevent breaking cell-wrapper and the cu charts (#1057).