### PR TITLE
feat!: add configurable slack channel

### DIFF
--- a/charts/drax/configuration/grafana/alerting/contactpoints.yaml
+++ b/charts/drax/configuration/grafana/alerting/contactpoints.yaml
@@ -1,15 +1,23 @@
+{{- if $.Values.global.alerting.enabled -}}
+{{- if eq $.Values.global.alerting.channel "" -}}
+  {{- fail "A slack channel needs to be provided when alerting is enabled (global.alerting.channel). Please set a valid Slack channel name or Slack ID." }}
+{{- end -}}
+{{- end -}}
+
 apiVersion: 1
 contactPoints:
   - orgId: 1
     name: accelleran-drax
     receivers:
+      {{- if and ($.Values.global.alerting.enabled) (ne $.Values.global.alerting.channel "") }}
       - uid: aebke0ctqjxttd
         type: slack
         settings:
-          recipient: drax-notifications
+          recipient: {{ $.Values.global.alerting.channel }}
           token: {{- if $.Values.global.alerting.enabled }} ${SLACK_TOKEN}{{- else }} "-"{{- end }}
           username: Grafana Alert Bot
         disableResolveMessage: true
+      {{- end }}
       - uid: febke0ctqjxtua
         type: webhook
         settings:

--- a/charts/drax/configuration/grafana/alerting/contactpoints.yaml
+++ b/charts/drax/configuration/grafana/alerting/contactpoints.yaml
@@ -9,7 +9,7 @@ contactPoints:
   - orgId: 1
     name: accelleran-drax
     receivers:
-      {{- if and ((($.Values.global).alerting).enabled) (ne (($.Values.global).alerting).channel "") }}
+      {{- if and ((($.Values.global).alerting).enabled) (empty (($.Values.global).alerting).channel) }}
       - uid: aebke0ctqjxttd
         type: slack
         settings:

--- a/charts/drax/configuration/grafana/alerting/contactpoints.yaml
+++ b/charts/drax/configuration/grafana/alerting/contactpoints.yaml
@@ -9,7 +9,7 @@ contactPoints:
   - orgId: 1
     name: accelleran-drax
     receivers:
-      {{- if and ($.Values.global.alerting.enabled) (ne $.Values.global.alerting.channel "") }}
+      {{- if and ((($.Values.global).alerting).enabled) (ne (($.Values.global).alerting).channel "") }}
       - uid: aebke0ctqjxttd
         type: slack
         settings:

--- a/charts/drax/configuration/grafana/alerting/contactpoints.yaml
+++ b/charts/drax/configuration/grafana/alerting/contactpoints.yaml
@@ -9,7 +9,7 @@ contactPoints:
   - orgId: 1
     name: accelleran-drax
     receivers:
-      {{- if and ((($.Values.global).alerting).enabled) (empty (($.Values.global).alerting).channel) }}
+      {{- if and ((($.Values.global).alerting).enabled) (not (empty (($.Values.global).alerting).channel)) }}
       - uid: aebke0ctqjxttd
         type: slack
         settings:

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -68,14 +68,17 @@ global:
   #                       when set to `false`, alerts are not provisioned.
   #     - `slackToken`:   Required: The token used to configure the Slack contact point for alert notifications.
   #                       This token allows alerts to be sent via Slack.
+  #     - `channel`:      Required: The Slack channel name or channel ID where alerts will be sent.
   #
   #   Value types:
   #     - enabled: boolean
   #     - slackToken: string
+  #     - channel: string
   #
   alerting:
     enabled: false
     slackToken: ""
+    channel: ""
 
   persistentLogLevel: info
 


### PR DESCRIPTION
This PR adds the possibility to configure a slack channel name or id in the helm chart values file.

This new values is required when dRAX alerting is activated.

This PR also removes the default slack channel that was "drax-notifications"