### PR TITLE
revert: fix du metrics server exposure for DU

### DIFF
--- a/charts/du-metrics-server/values.yaml
+++ b/charts/du-metrics-server/values.yaml
@@ -78,11 +78,12 @@ du-metrics-server:
   service:
     enabled: true
     name: ""
-    type: ClusterIP
+    type: NodePort
     ports:
       metric:
         port: 55555
         targetPort: 55555
+        nodePort: 31555
         protocol: UDP
 
 


### PR DESCRIPTION
This reverts the closing down of the du metrics server nodeport service. The DU will still need to be able to connect, hence it needs to be restored for now.