### PR TITLE
feat: allow to pull external (OCI) charts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,8 +39,9 @@
         "(^|/)External\\.yaml$"
       ],
       "matchStrings": [
-        "name:\\s+\"?(?<depName>.*?)\"?\\s+(.*\\s)?repository:\\s+\"?oci://(?<registryUrl>.*?)\"?\\s+(.*\\s)?version:\\s+\"?(?<currentValue>[\\w\\.\\-]*)\"?"
-      ]
+        "name:\\s+\"?(?<chartName>.*?)\"?\\s+(.*\\s)?repository:\\s+\"?oci://(?<registryRef>.*?)\"?\\s+(.*\\s)?version:\\s+\"?(?<currentValue>[\\w\\.\\-]*)\"?"
+      ],
+      "packageNameTemplate": "{{registryRef}}/{{chartName}}"
     },
     {
       "customType": "regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,16 @@
       "customType": "regex",
       "datasourceTemplate": "docker",
       "fileMatch": [
+        "(^|/)External\\.yaml$"
+      ],
+      "matchStrings": [
+        "name:\\s+\"?(?<depName>.*?)\"?\\s+(.*\\s)?repository:\\s+\"?oci://(?<registryUrl>.*?)\"?\\s+(.*\\s)?version:\\s+\"?(?<currentValue>[\\w\\.\\-]*)\"?"
+      ]
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "fileMatch": [
         "(^|/)values\\.y[a]?ml$"
       ],
       "matchStrings": [
@@ -63,6 +73,15 @@
         "#\\s?renovate: github_repository=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extract_version=(?<extractVersion>.*?))?\\s*[\\w\\-]*_version:\\s?\"?(?<currentValue>[\\w+\\.\\-]*)\"?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge external chart updates",
+      "automerge": true,
+      "matchFileNames": [
+        "/External\\.yaml/"
+      ]
     }
   ]
 }

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -242,7 +242,7 @@ jobs:
 
   release-charts:
     name: Release Charts
-    if: ${{ needs.vars.outputs.is_main_branch == 'true' || needs.vars.outputs.is_release_branch == 'true' }}
+    if: ${{ needs.vars.outputs.is_main_branch == 'true' || needs.vars.outputs.is_release_branch == 'true' && !cancelled() && !failure() }}
     needs:
       - vars
       - lint-charts
@@ -305,7 +305,7 @@ jobs:
 
   release-please:
     name: Release
-    if: ${{ needs.vars.outputs.is_main_branch == 'true' || needs.vars.outputs.is_release_branch == 'true' }}
+    if: ${{ needs.vars.outputs.is_main_branch == 'true' || needs.vars.outputs.is_release_branch == 'true' && !cancelled() && !failure() }}
     # Run after release-charts so that the tag exists in case of release commits.
     # Otherwise release please will create a new PR
     # as it doesn't yet have the release to compare changes with.

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -271,6 +271,15 @@ jobs:
       - name: Add helm repositories
         run: ./bin/add-repos
 
+      - name: Login to Docker Hub
+        run: helm registry login --username ${{ secrets.DOCKER_LOGIN }} --password ${{ secrets.DOCKER_ACCESS_TOKEN }} docker.io
+
+      - name: Login to GHCR
+        run: helm registry login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
+      - name: Pull external helm charts
+        run: ./bin/pull-external-charts
+
       - name: Generate release notes
         run: ./bin/generate-release-notes
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ then a flag can be added to the script:
 
 This is for example handy during development on the `common` library chart.
 
+## External charts
+
+It is possible to pull in an external chart.
+
+To do this, in the `charts` directory a new chart directory should be created.
+This directory should then contain the file `External.yaml`.
+A format similar to an entry in `dependencies` in a `Chart.yaml` file can be provided in there.
+
+```yaml
+name: example-chart
+alias: example
+repository: oci://ghcr.io/accelleran
+version: 0.1.0
+```
+
+`alias` is an optional field here, in case we want to use a different name as the original chart.
+
+Also note that the version should be specific.
+So a version expressing a range like `0.1` is not supported.
+Renovate will bump the version automatically to always release the latest version of an external chart.
+
 ## New charts
 
 A bit of setup is needed for release please when adding a new chart.

--- a/bin/add-chart
+++ b/bin/add-chart
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(dirname "$0")
-GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 
 function print_error() {
     echo "${1}" 1>&2

--- a/bin/create-release-branch
+++ b/bin/create-release-branch
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(dirname "$0")
-GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 
 function usage() {
     echo "Usage:"

--- a/bin/generate-release-notes
+++ b/bin/generate-release-notes
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(dirname "$0")
-GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 CHARTS_ROOT="${GIT_ROOT}/charts"
 
 printf "Generating release notes\n"

--- a/bin/pull-external-charts
+++ b/bin/pull-external-charts
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -eu -o pipefail
+shopt -s nullglob
+
 GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 CHARTS_ROOT="${GIT_ROOT}/charts"
 
@@ -23,12 +26,12 @@ exit_status=0
 
 for ext in "$CHARTS_ROOT"/**/External.yaml ; do
     chart_dir="$(dirname "$ext")"
-    chart_name="$(yq ".name" "$ext")"
-    chart_alias="$(yq ".alias // \"\"" "$ext")"
-    chart_repository="$(yq ".repository" "$ext")"
-    chart_version="$(yq ".version" "$ext")"
+    chart_name="$(yq '.name' "$ext")"
+    chart_alias="$(yq '.alias // ""' "$ext")"
+    chart_repository="$(yq '.repository' "$ext")"
+    chart_version="$(yq '.version' "$ext")"
 
-    if [[ "$(echo "$chart_repository" | cut -d: -f 1)" != "oci" ]] ; then
+    if [[ "$chart_repository" != oci://* ]] ; then
         error "Only OCI repositories are supported for external charts"
         exit_status=1
         continue

--- a/bin/pull-external-charts
+++ b/bin/pull-external-charts
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(dirname "$0")
-GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 CHARTS_ROOT="${GIT_ROOT}/charts"
 
 function fatal() {

--- a/bin/pull-external-charts
+++ b/bin/pull-external-charts
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+BASE_DIR=$(dirname "$0")
+GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+CHARTS_ROOT="${GIT_ROOT}/charts"
+
+function fatal() {
+    error "${@}"
+    exit 1
+}
+
+function error() {
+    echo "${1}" 1>&2
+}
+
+if [[ ! "$(yq --version)" =~ .*mikefarah/yq.* ]]; then
+    fatal "Make sure to install mikefarah/yq"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap "rm -rf '$TMP_DIR'" EXIT
+
+exit_status=0
+
+for ext in "$CHARTS_ROOT"/**/External.yaml ; do
+    chart_dir="$(dirname "$ext")"
+    chart_name="$(yq ".name" "$ext")"
+    chart_alias="$(yq ".alias // \"\"" "$ext")"
+    chart_repository="$(yq ".repository" "$ext")"
+    chart_version="$(yq ".version" "$ext")"
+
+    if [[ "$(echo "$chart_repository" | cut -d: -f 1)" != "oci" ]] ; then
+        error "Only OCI repositories are supported for external charts"
+        exit_status=1
+        continue
+    fi
+
+    TMP_UNTAR_DIR="$(mktemp -d --tmpdir="$TMP_DIR")"
+
+    echo "Pulling $chart_name version $chart_version"
+    if ! helm pull "$chart_repository/$chart_name" --version "$chart_version" --destination "$TMP_DIR" --untar --untardir "$TMP_UNTAR_DIR" ; then
+        error "Failed to pull $chart_repository/$chart_name:$chart_version"
+        exit_status=1
+        continue
+    fi
+
+    echo "Moving $chart_name to $chart_dir"
+    if ! mv  "$TMP_UNTAR_DIR"/*/* "$chart_dir/" ; then
+        error "Failed to move $chart_repository/$chart_name:$chart_version to $chart_dir"
+        exit_status=1
+    fi
+
+    if [ -n "$chart_alias" ] ; then
+        echo "Setting alias $chart_alias for $chart_name"
+        yq -i ".name = \"$chart_alias\"" "$chart_dir/Chart.yaml"
+    fi
+done
+
+exit "$exit_status"

--- a/bin/release-legacy-chart
+++ b/bin/release-legacy-chart
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(dirname "$0")
-GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 
 function usage() {
     echo "Usage:"

--- a/bin/update-deps
+++ b/bin/update-deps
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(dirname "$0")
-GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+GIT_ROOT="$(realpath "$(dirname "$0")/..")"
 CHARTS_ROOT="${GIT_ROOT}/charts"
 
 function usage() {


### PR DESCRIPTION
To pull external charts in (only from an OCI registry), we need a chart in the `charts` dir, but the contents should only be a single file `External.yaml`.
Then the `External.yaml` file should contain someting similar to a `dependencies` entry found in a normal `Chart.yaml` file:

```yaml
name: cu-cp-chart
alias: cu-cp
repository: oci://ghcr.io/accelleran
version: 12.0.0
```

`alias` is an optional field in case we want to use a different name as the original chart.

The repository and name is also a proposal for how we organize ourselves with OCI charts.
We could also use docker hub, though note that an explicit registry is required for helm as it has no default fallback.
Also docker doesn't support using a `/` in the repository (contrary to ghcr), so we can't for example use a repo prefix like `accelleran/helm-charts` that would look like `oci://ghcr.io/accelleran/helm-charts/cu-cp` in the end result.
This means that the chart name needs to be different than the docker image name, hence the `-chart` suffix.
I would still adapt to these limitations when using ghcr to keep the option open for both registries in a consistent way.

Note also that for renovate we should use a specific version, so we can't use a version range like we otherwise could with helm.
Also the order of all the keys is important as a regex manager is used within renovate.

I've also added a package rule for external charts to let renovate immediately automerge them.
Here I make the assumption that the external chart release process has tested the chart properly.
To further support this we could extract some (composite) actions from the current workflow for easy use in this repo and externally.

_Currently I've also made up something to login to ghcr.
GitHup Apps are not supported at the moment to login to ghcr, so we'll need to see how we access the external charts if using ghcr._ This is not an issue actually as the token isn't representing some kind of GitHub App "GitHub Actions" as I thought first, but the original "actor" of the workflow (`${{ github.actor }}`. Hence that's also the username we need to supply.