### PR TITLE
fix: fix e1 app protocol

### DIFF
--- a/charts/cu-cp/values.yaml
+++ b/charts/cu-cp/values.yaml
@@ -62,7 +62,7 @@ service:
   type: "LoadBalancer"
   ports:
     e1ap:
-      appProtocol: "e1-control"
+      appProtocol: "e1-interface"
       protocol: "SCTP"
       port: 38462
       targetPort: 0


### PR DESCRIPTION
There was a regression with the introduction of the monolothic CU charts in the e1 app protocol. We follow the IANA service names, but these are not really consistent unfortunately. So instead of `e1-control`, it should be `e1-interface` (https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=e1-interface).