### PR TITLE
fix(mergeability): fix release notes

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -263,6 +263,9 @@ jobs:
       - name: Add helm repositories
         run: ./bin/add-repos
 
+      - name: Generate release notes
+        run: ./bin/generate-release-notes
+
       - name: Run chart releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/*.tgz
+**/RELEASE_NOTES.md
+
 venv/
 .idea

--- a/bin/generate-release-notes
+++ b/bin/generate-release-notes
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BASE_DIR=$(dirname "$0")
+GIT_ROOT=$(cd "${BASE_DIR}/.." && pwd)
+CHARTS_ROOT="${GIT_ROOT}/charts"
+
+printf "Generating release notes\n"
+
+for chart in "${CHARTS_ROOT}"/*/ "${CHARTS_ROOT}"/drax/charts/*/ ; do
+    if [[ ! -f "$chart/CHANGELOG.md" ]] ; then
+        printf "\nNo changelog - Skip generating release notes for %s\n\n" "$chart"
+    else
+        printf "\nGenerating release notes for %s...\n\n" "$chart"
+        sed -n '/# Changelog/{:a;N;s/^## /&/mp2;Ta}' "$chart/CHANGELOG.md" | head -n -2 > "$chart/RELEASE_NOTES.md"
+    fi
+done

--- a/etc/cr.yaml
+++ b/etc/cr.yaml
@@ -1,3 +1,3 @@
 charts-dir: charts
 skip-existing: true
-release-notes-file: CHANGELOG.md
+release-notes-file: RELEASE_NOTES.md


### PR DESCRIPTION
The drax changelog grow so big that the github release body was denied due to its size.
As we were pushing in the whole changelog, the release notes were also unnecessarily big.
Instead just the top portion for the actual release should be included.

In this PR we put the top of the changelog into a separate file `RELEASE_NOTES.md` which the helm chart releaser can then use to include in the github release description. It is always running for all charts as chart releaser will also work on all charts with every run (it just skips releasing if a github release already exists).
These release notes files are also ignored by git as it is meant as just an artifact for the CI pipeline.

Note that the `sed` command is a bit complex as we need to leave in everything until the second occurrence of a release title.