### PR TITLE
fix: fix grafana capabilities to do a recursive chown

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1159,6 +1159,15 @@ grafana:
     drax/role: ric
     drax/component-name: grafana
 
+  initChownData:
+    securityContext:
+      capabilities:
+        add:
+          - CHOWN
+          - DAC_READ_SEARCH
+        drop:
+          - ALL
+
   persistence:
     type: pvc
     enabled: true


### PR DESCRIPTION
This is a work-around for a bug introduced by grafana in their helm chart.