### PR TITLE
fix: disable flaky grafana tests

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1460,6 +1460,9 @@ grafana:
     kafka-cluster-monitoring: "{{ .Release.Name }}-grafana-kafka-cluster-monitoring"
     nats-dashboard: "{{ .Release.Name }}-grafana-nats-dashboard"
 
+  testFramework:
+    enabled: false
+
 
 loki-gateway:
   # enabled: true


### PR DESCRIPTION
The grafana tests that are executed are quite flaky and result in lots of reruns. As these don't provide additional value to us there is no point in leaving these enabled.