### PR TITLE
chore: add environment variable to grafana to stop it sanitizing html

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1251,6 +1251,9 @@ grafana:
         name: "{{ $.Release.Name }}-slack-auth"
         key: slack-token
 
+  env:
+    GF_PANELS_DISABLE_SANITIZE_HTML: false
+
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
This introduces an environment variable to Grafana which if set to true stops it sanitising HTML so JavaScript frames can be embedded into dashboards. It is set to false by default.