### PR TITLE
ci: block merging only on failed release please commits

### DIFF
--- a/.github/actions/block-merging/action.yml
+++ b/.github/actions/block-merging/action.yml
@@ -7,6 +7,11 @@ inputs:
   branch:
     description: Target branch to check
     default: main
+  filter:
+    description: |-
+      Regex filter for last commit message on the target branch.
+      Allows merging immediately when the commit message doesn't match.
+    default: .*
   bypass_prefix:
     description: Commit message prefix to bypass the check
     default: "fix(mergeability): "
@@ -22,6 +27,7 @@ runs:
       env:
         BRANCH: ${{ inputs.branch }}
         BYPASS_PREFIX: ${{ inputs.bypass_prefix }}
+        FILTER: ${{ inputs.filter }}
         MAX_WAIT_TIME: ${{ inputs.max_wait_time }}
         PR_TITLE: ${{ github.event.pull_request.title }}
       with:
@@ -29,12 +35,56 @@ runs:
         script: |-
           const {owner,repo} = context.repo;
           const branch = process.env.BRANCH;
-
+          const filter = process.env.FILTER;
           const prTitle = process.env.PR_TITLE;
           const bypassPrefix = process.env.BYPASS_PREFIX;
 
           if (prTitle.startsWith(bypassPrefix)) {
             console.log(`Merging is allowed as the PR title ("${prTitle}") matches the bypass prefix ("${bypassPrefix}")`);
+            process.exit(0);
+          }
+
+          const lastCommitMessage = await (async () => {
+            const refsResponse = await github.rest.git.listMatchingRefs({
+              owner: owner,
+              repo: repo,
+              ref: `heads/${branch}`,
+            });
+            if (refsResponse.status != 200) {
+              throw new Error(`Refs for heads/${branch} couldn't be retrieved`);
+            }
+
+            let commitSha = "";
+
+            const refs = refsResponse.data;
+            for (const ref of refs) {
+              if (ref.object.type === "commit") {
+                commitSha = ref.object.sha;
+                break;
+              }
+            }
+
+            if (commitSha === "") {
+              throw new Error(`No commit SHA could be found in matched refs (length ${refs.length})`);
+            }
+
+            const commitResponse = await github.rest.git.getCommit({
+              owner: owner,
+              repo: repo,
+              commit_sha: commitSha,
+            });
+            if (commitResponse.status != 200) {
+              throw new Error(`Commit for sha ${commitSha} couldn't be retrieved`);
+            }
+
+            let commit = commitResponse.data;
+
+            return commit.message;
+          })();
+
+          const filterRegex = new RegExp(filter);
+          if (!filterRegex.test(lastCommitMessage)) {
+            console.log(`Merging is allowed as the last commit message ("${lastCommitMessage}") doesn't match the filter ("${filter}")`);
             process.exit(0);
           }
 

--- a/.github/actions/block-merging/action.yml
+++ b/.github/actions/block-merging/action.yml
@@ -39,15 +39,33 @@ runs:
           const prTitle = process.env.PR_TITLE;
           const bypassPrefix = process.env.BYPASS_PREFIX;
 
-          if (prTitle.startsWith(bypassPrefix)) {
-            console.log(
-              `Merging is allowed as the PR title ("${prTitle}") matches the bypass prefix ("${bypassPrefix}")`,
-            );
-            process.exit(0);
-          }
-
           const filterRegex = new RegExp(filter);
-          const lastCommitMessage = await (async () => {
+
+          const maxWaitTimeString = process.env.MAX_WAIT_TIME;
+          const { hours, minutes, seconds } =
+            /^(?<hours>[0-9]*)h?(?<minutes>[0-9]*)m?(?<seconds>[0-9]*)s?$/.exec(
+              maxWaitTimeString,
+            ).groups;
+          const maxWaitTimeMs = (hours || 0) * 3600000 +
+            (minutes || 0) * 60000 +
+            (seconds || 0) * 1000;
+          const attemptDelayMs = 5000;
+          const maxAttempts = (maxWaitTimeMs || Infinity) / attemptDelayMs;
+
+          const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+          const retry = async (fn, maxAttempts) => {
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
+              try {
+                return await fn();
+              } catch (err) {
+                console.error(`Error in attempt ${attempt}: ${err.message}`);
+                await sleep(attemptDelayMs);
+              }
+            }
+          };
+
+          const fetchLastCommitMessage = async () => {
             const refsResponse = await github.rest.git.listMatchingRefs({
               owner: owner,
               repo: repo,
@@ -85,37 +103,6 @@ runs:
             let commit = commitResponse.data;
 
             return commit.message;
-          })();
-
-          if (!filterRegex.test(lastCommitMessage)) {
-            console.log(
-              `Merging is allowed as the last commit message ("${lastCommitMessage}") doesn't match the filter ("${filter}")`,
-            );
-            process.exit(0);
-          }
-
-          const maxWaitTimeString = process.env.MAX_WAIT_TIME;
-          const { hours, minutes, seconds } =
-            /^(?<hours>[0-9]*)h?(?<minutes>[0-9]*)m?(?<seconds>[0-9]*)s?$/.exec(
-              maxWaitTimeString,
-            ).groups;
-          const maxWaitTimeMs = (hours || 0) * 3600000 +
-            (minutes || 0) * 60000 +
-            (seconds || 0) * 1000;
-          const attemptDelayMs = 5000;
-          const maxAttempts = (maxWaitTimeMs || Infinity) / attemptDelayMs;
-
-          const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-          const retry = async (fn, maxAttempts) => {
-            for (let attempt = 0; attempt < maxAttempts; attempt++) {
-              try {
-                return await fn();
-              } catch (err) {
-                console.error(`Error in attempt ${attempt}: ${err.message}`);
-                await sleep(attemptDelayMs);
-              }
-            }
           };
 
           const fetchCompletedChecks = async () => {
@@ -140,6 +127,21 @@ runs:
 
             return checks;
           };
+
+          if (prTitle.startsWith(bypassPrefix)) {
+            console.log(
+              `Merging is allowed as the PR title ("${prTitle}") matches the bypass prefix ("${bypassPrefix}")`,
+            );
+            process.exit(0);
+          }
+
+          const lastCommitMessage = await fetchLastCommitMessage();
+          if (!filterRegex.test(lastCommitMessage)) {
+            console.log(
+              `Merging is allowed as the last commit message ("${lastCommitMessage}") doesn't match the filter ("${filter}")`,
+            );
+            process.exit(0);
+          }
 
           const completedChecks = await retry(fetchCompletedChecks, maxAttempts);
 

--- a/.github/actions/block-merging/action.yml
+++ b/.github/actions/block-merging/action.yml
@@ -10,6 +10,9 @@ inputs:
   bypass_prefix:
     description: Commit message prefix to bypass the check
     default: "fix(mergeability): "
+  max_wait_time:
+    description: Maximum time to wait for checks to complete
+    default: 4h
 runs:
   using: "composite"
   steps:
@@ -19,6 +22,7 @@ runs:
       env:
         BRANCH: ${{ inputs.branch }}
         BYPASS_PREFIX: ${{ inputs.bypass_prefix }}
+        MAX_WAIT_TIME: ${{ inputs.max_wait_time }}
         PR_TITLE: ${{ github.event.pull_request.title }}
       with:
         github-token: ${{ inputs.github_token }}
@@ -34,6 +38,14 @@ runs:
             process.exit(0);
           }
 
+          const maxWaitTimeString = process.env.MAX_WAIT_TIME;
+          const {hours,minutes,seconds} = /^(?<hours>[0-9]*)h?(?<minutes>[0-9]*)m?(?<seconds>[0-9]*)s?$/.exec(maxWaitTimeString).groups;
+          const maxWaitTimeMs = (hours || 0) * 3600000
+                              + (minutes || 0) * 60000
+                              + (seconds || 0) * 1000;
+          const attemptDelayMs = 5000;
+          const maxAttempts = (maxWaitTimeMs || Infinity) / attemptDelayMs;
+
           const sleep = ms => new Promise(r => setTimeout(r, ms));
 
           const retry = async (fn, maxAttempts) => {
@@ -42,7 +54,7 @@ runs:
                 return await fn();
               } catch (err) {
                 console.error(`Error in attempt ${attempt}: ${err.message}`);
-                await sleep(5000);
+                await sleep(attemptDelayMs);
               }
             }
           };
@@ -69,7 +81,7 @@ runs:
           };
 
 
-          const completedChecks = await retry(fetchCompletedChecks, Infinity);
+          const completedChecks = await retry(fetchCompletedChecks, maxAttempts);
 
           for (const check of completedChecks) {
             if (check.conclusion === "failure") {

--- a/.github/actions/block-merging/action.yml
+++ b/.github/actions/block-merging/action.yml
@@ -33,17 +33,20 @@ runs:
       with:
         github-token: ${{ inputs.github_token }}
         script: |-
-          const {owner,repo} = context.repo;
+          const { owner, repo } = context.repo;
           const branch = process.env.BRANCH;
           const filter = process.env.FILTER;
           const prTitle = process.env.PR_TITLE;
           const bypassPrefix = process.env.BYPASS_PREFIX;
 
           if (prTitle.startsWith(bypassPrefix)) {
-            console.log(`Merging is allowed as the PR title ("${prTitle}") matches the bypass prefix ("${bypassPrefix}")`);
+            console.log(
+              `Merging is allowed as the PR title ("${prTitle}") matches the bypass prefix ("${bypassPrefix}")`,
+            );
             process.exit(0);
           }
 
+          const filterRegex = new RegExp(filter);
           const lastCommitMessage = await (async () => {
             const refsResponse = await github.rest.git.listMatchingRefs({
               owner: owner,
@@ -65,7 +68,9 @@ runs:
             }
 
             if (commitSha === "") {
-              throw new Error(`No commit SHA could be found in matched refs (length ${refs.length})`);
+              throw new Error(
+                `No commit SHA could be found in matched refs (length ${refs.length})`,
+              );
             }
 
             const commitResponse = await github.rest.git.getCommit({
@@ -82,21 +87,25 @@ runs:
             return commit.message;
           })();
 
-          const filterRegex = new RegExp(filter);
           if (!filterRegex.test(lastCommitMessage)) {
-            console.log(`Merging is allowed as the last commit message ("${lastCommitMessage}") doesn't match the filter ("${filter}")`);
+            console.log(
+              `Merging is allowed as the last commit message ("${lastCommitMessage}") doesn't match the filter ("${filter}")`,
+            );
             process.exit(0);
           }
 
           const maxWaitTimeString = process.env.MAX_WAIT_TIME;
-          const {hours,minutes,seconds} = /^(?<hours>[0-9]*)h?(?<minutes>[0-9]*)m?(?<seconds>[0-9]*)s?$/.exec(maxWaitTimeString).groups;
-          const maxWaitTimeMs = (hours || 0) * 3600000
-                              + (minutes || 0) * 60000
-                              + (seconds || 0) * 1000;
+          const { hours, minutes, seconds } =
+            /^(?<hours>[0-9]*)h?(?<minutes>[0-9]*)m?(?<seconds>[0-9]*)s?$/.exec(
+              maxWaitTimeString,
+            ).groups;
+          const maxWaitTimeMs = (hours || 0) * 3600000 +
+            (minutes || 0) * 60000 +
+            (seconds || 0) * 1000;
           const attemptDelayMs = 5000;
           const maxAttempts = (maxWaitTimeMs || Infinity) / attemptDelayMs;
 
-          const sleep = ms => new Promise(r => setTimeout(r, ms));
+          const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
           const retry = async (fn, maxAttempts) => {
             for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -123,22 +132,27 @@ runs:
 
             for (const check of checks) {
               if (check.status !== "completed") {
-                throw new Error(`Merging is blocked as the checks for ${branch} haven't completed yet`);
+                throw new Error(
+                  `Merging is blocked as the checks for ${branch} haven't completed yet`,
+                );
               }
             }
 
             return checks;
           };
 
-
           const completedChecks = await retry(fetchCompletedChecks, maxAttempts);
 
           for (const check of completedChecks) {
             if (check.conclusion === "failure") {
-              core.setFailed(`Merging is blocked as the checks for ${branch} include a failure`);
+              core.setFailed(
+                `Merging is blocked as the checks for ${branch} include a failure`,
+              );
               process.exit(1);
             }
           }
 
-          console.log(`Merging is allowed as all checks for ${branch} have completed without failures`);
+          console.log(
+            `Merging is allowed as all checks for ${branch} have completed without failures`,
+          );
           process.exit(0);

--- a/.github/actions/block-merging/action.yml
+++ b/.github/actions/block-merging/action.yml
@@ -46,9 +46,8 @@ runs:
             /^(?<hours>[0-9]*)h?(?<minutes>[0-9]*)m?(?<seconds>[0-9]*)s?$/.exec(
               maxWaitTimeString,
             ).groups;
-          const maxWaitTimeMs = (hours || 0) * 3600000 +
-            (minutes || 0) * 60000 +
-            (seconds || 0) * 1000;
+          const maxWaitTimeMs =
+            (((hours || 0) * 60 + (minutes || 0)) * 60 + (seconds || 0)) * 1000;
           const attemptDelayMs = 5000;
           const maxAttempts = (maxWaitTimeMs || Infinity) / attemptDelayMs;
 

--- a/.github/workflows/mergeability.yaml
+++ b/.github/workflows/mergeability.yaml
@@ -26,3 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: 'main'
+          filter: 'chore: release .*'


### PR DESCRIPTION
In this PR a filter is added to the block-merging action.

The reason this action and workflow was originally introduced was to ensure release please doesn't mess up the changelog in a release PR. This happened when chart releaser tagged on a later commit than the merged one (due to a flaky failure during the original merge).

So now we only wait (or fail) when a merged release please commit is still running (has failed) on the `main` branch.

Also a max wait time is included.