### PR TITLE
fix: fix name and component labels

### DIFF
--- a/charts/cu-cp/templates/_helpers.tpl
+++ b/charts/cu-cp/templates/_helpers.tpl
@@ -14,3 +14,44 @@ bootstrapConfigMapName: {{ include "accelleran.common.bootstrap.configMapName" (
 accelleranLicense:
   enabled: false
 {{- end -}}
+
+
+{{- define "accelleran.cu-cp.selectorLabels" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to cu-cp selector labels" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{
+  include "accelleran.common.selectorLabels"
+    (dict
+      "top" $
+      "values" (mergeOverwrite
+        (deepCopy $values)
+        (dict
+          "nameOverride" $.Values.nameOverride
+          "fullnameOverride" $.Values.fullnameOverride
+        )
+      )
+    )
+}}
+app.kubernetes.io/component: {{ $values.component }}
+{{- end -}}
+
+
+{{- define "accelleran.cu-cp.labels" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to cu-cp labels" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{
+  include "accelleran.common.labels"
+    (dict
+      "top" $
+      "values" (mergeOverwrite
+        (deepCopy $values)
+        (dict
+          "nameOverride" $.Values.nameOverride
+          "fullnameOverride" $.Values.fullnameOverride
+        )
+      )
+    )
+  }}
+{{- end -}}

--- a/charts/cu-cp/templates/service-cu-cp.yaml
+++ b/charts/cu-cp/templates/service-cu-cp.yaml
@@ -2,10 +2,9 @@
       "accelleran.common.service"
       (dict
         "top" $
-        "selectorLabels" (merge
-          (include "accelleran.common.selectorLabels" (dict "top" $) | fromYaml)
-          (dict "app.kubernetes.io/component" $.Values.component)
-        )
-        "labels" (include "accelleran.common.labels" (dict "top" $) | fromYaml)
+        "selectorLabels" 
+          (include "accelleran.cu-cp.selectorLabels" (dict "top" $) | fromYaml)
+        "labels" 
+          (include "accelleran.cu-cp.labels" (dict "top" $) | fromYaml)
       )
 -}}

--- a/charts/cu-cp/templates/statefulset-cu-cp.yaml
+++ b/charts/cu-cp/templates/statefulset-cu-cp.yaml
@@ -17,10 +17,9 @@ values:
   }}
 
 selectorLabels:
-  {{ include "accelleran.common.selectorLabels" (dict "top" $) | nindent 2 }}
-  app.kubernetes.io/component: {{ $.Values.component }}
+  {{ include "accelleran.cu-cp.selectorLabels" (dict "top" $) | nindent 2 }}
 labels:
-  {{ include "accelleran.common.labels" (dict "top" $) | nindent 2 }}
+  {{ include "accelleran.cu-cp.labels" (dict "top" $) | nindent 2 }}
 
 initContainers:
 - {{ fromYaml (include "accelleran.common.init.nats" (fromYaml (include "accelleran.cu-cp.init.args" .))) | toYaml | nindent 2 }}

--- a/charts/cu-up/templates/_helpers.tpl
+++ b/charts/cu-up/templates/_helpers.tpl
@@ -33,3 +33,44 @@ bootstrapConfigMapName: {{ include "accelleran.common.bootstrap.configMapName" (
 accelleranLicense:
   enabled: false
 {{- end -}}
+
+
+{{- define "accelleran.cu-up.selectorLabels" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to cu-up selector labels" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{
+  include "accelleran.common.selectorLabels"
+    (dict
+      "top" $
+      "values" (mergeOverwrite
+        (deepCopy $values)
+        (dict
+          "nameOverride" $.Values.nameOverride
+          "fullnameOverride" $.Values.fullnameOverride
+        )
+      )
+    )
+}}
+app.kubernetes.io/component: {{ $values.component }}
+{{- end -}}
+
+
+{{- define "accelleran.cu-up.labels" -}}
+{{- $ := get . "top" | required "The top context needs to be provided to cu-up labels" -}}
+{{- $values := get . "values" | default $.Values -}}
+
+{{
+  include "accelleran.common.labels"
+    (dict
+      "top" $
+      "values" (mergeOverwrite
+        (deepCopy $values)
+        (dict
+          "nameOverride" $.Values.nameOverride
+          "fullnameOverride" $.Values.fullnameOverride
+        )
+      )
+    )
+  }}
+{{- end -}}

--- a/charts/cu-up/templates/deployment-ups.yaml
+++ b/charts/cu-up/templates/deployment-ups.yaml
@@ -22,7 +22,6 @@ name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "val
 
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
-  app.kubernetes.io/component: {{ $values.component }}
   up-stack-id: {{ $ordinal | quote }}
 
 volumes:

--- a/charts/cu-up/templates/deployment-ups.yaml
+++ b/charts/cu-up/templates/deployment-ups.yaml
@@ -22,6 +22,7 @@ name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "val
 
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
+  app.kubernetes.io/component: {{ $values.component }}
   up-stack-id: {{ $ordinal | quote }}
 
 volumes:

--- a/charts/cu-up/templates/deployment-ups.yaml
+++ b/charts/cu-up/templates/deployment-ups.yaml
@@ -20,6 +20,9 @@ values:
 
 name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "values" $values)) $ordinal }}
 
+labels:
+  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
+  up-stack-id: {{ $ordinal | quote }}
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
   app.kubernetes.io/component: {{ $values.component }}

--- a/charts/cu-up/templates/deployment-ups.yaml
+++ b/charts/cu-up/templates/deployment-ups.yaml
@@ -20,12 +20,25 @@ values:
 
 name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "values" $values)) $ordinal }}
 
-labels:
-  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
-  up-stack-id: {{ $ordinal | quote }}
 selectorLabels:
-  {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
-  app.kubernetes.io/component: {{ $values.component }}
+  {{
+    include "accelleran.cu-up.selectorLabels"
+      (dict
+        "top" $
+        "values" $values
+      )
+    | nindent 2
+  }}
+  up-stack-id: {{ $ordinal | quote }}
+labels:
+  {{
+    include "accelleran.cu-up.labels"
+      (dict
+        "top" $
+        "values" $values
+      )
+    | nindent 2
+  }}
   up-stack-id: {{ $ordinal | quote }}
 
 volumes:

--- a/charts/cu-up/templates/deployment-xdp-ups.yaml
+++ b/charts/cu-up/templates/deployment-xdp-ups.yaml
@@ -31,12 +31,25 @@ values:
 
 name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "values" $values)) $ordinal }}
 
-labels:
-  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
-  up-stack-id: {{ $ordinal | quote }}
 selectorLabels:
-  {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
-  app.kubernetes.io/component: {{ $values.component }}
+  {{
+    include "accelleran.cu-up.selectorLabels"
+      (dict
+        "top" $
+        "values" $values
+      )
+    | nindent 2
+  }}
+  up-stack-id: {{ $ordinal | quote }}
+labels:
+  {{
+    include "accelleran.cu-up.labels"
+      (dict
+        "top" $
+        "values" $values
+      )
+    | nindent 2
+  }}
   up-stack-id: {{ $ordinal | quote }}
 
 initContainers:

--- a/charts/cu-up/templates/deployment-xdp-ups.yaml
+++ b/charts/cu-up/templates/deployment-xdp-ups.yaml
@@ -33,7 +33,6 @@ name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "val
 
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
-  app.kubernetes.io/component: {{ $values.component }}
   up-stack-id: {{ $ordinal | quote }}
 
 initContainers:

--- a/charts/cu-up/templates/deployment-xdp-ups.yaml
+++ b/charts/cu-up/templates/deployment-xdp-ups.yaml
@@ -31,6 +31,9 @@ values:
 
 name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "values" $values)) $ordinal }}
 
+labels:
+  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
+  up-stack-id: {{ $ordinal | quote }}
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
   app.kubernetes.io/component: {{ $values.component }}

--- a/charts/cu-up/templates/deployment-xdp-ups.yaml
+++ b/charts/cu-up/templates/deployment-xdp-ups.yaml
@@ -33,6 +33,7 @@ name: {{ printf "%s-%d" (include "accelleran.common.fullname" (dict "top" $ "val
 
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
+  app.kubernetes.io/component: {{ $values.component }}
   up-stack-id: {{ $ordinal | quote }}
 
 initContainers:

--- a/charts/cu-up/templates/rbac-ups.yaml
+++ b/charts/cu-up/templates/rbac-ups.yaml
@@ -3,6 +3,10 @@
       (dict
         "top" $
         "values" $.Values.ups
+        "selectorLabels"
+          (include "accelleran.cu-up.selectorLabels" (dict "top" $ "values" $.Values.ups) | fromYaml)
+        "labels" 
+          (include "accelleran.cu-up.labels" (dict "top" $ "values" $.Values.ups) | fromYaml)
       )
 }}
 ---
@@ -11,5 +15,9 @@
       (dict
         "top" $
         "values" $.Values.ups
+        "selectorLabels"
+          (include "accelleran.cu-up.selectorLabels" (dict "top" $ "values" $.Values.ups) | fromYaml)
+        "labels" 
+          (include "accelleran.cu-up.labels" (dict "top" $ "values" $.Values.ups) | fromYaml)
       )
 }}

--- a/charts/cu-up/templates/service-cu-up.yaml
+++ b/charts/cu-up/templates/service-cu-up.yaml
@@ -2,10 +2,9 @@
       "accelleran.common.service"
       (dict
         "top" $
-        "selectorLabels" (merge
-          (include "accelleran.common.selectorLabels" (dict "top" $) | fromYaml)
-          (dict "app.kubernetes.io/component" $.Values.component)
-        )
-        "labels" (include "accelleran.common.labels" (dict "top" $) | fromYaml)
+        "selectorLabels"
+          (include "accelleran.cu-up.selectorLabels" (dict "top" $) | fromYaml)
+        "labels" 
+          (include "accelleran.cu-up.labels" (dict "top" $) | fromYaml)
       )
 -}}

--- a/charts/cu-up/templates/service-gtp-u.yaml
+++ b/charts/cu-up/templates/service-gtp-u.yaml
@@ -20,11 +20,24 @@ values:
 
 serviceName: {{ (include "accelleran.cu-up.gtp-u.service.name" (list $ $ordinal)) | quote }}
 
-labels:
-  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
-  up-stack-id: {{ $ordinal | quote }}
 selectorLabels:
-  {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
-  app.kubernetes.io/component: {{ $values.component }}
+  {{
+    include "accelleran.cu-up.selectorLabels"
+      (dict
+        "top" $
+        "values" $values
+      )
+    | nindent 2
+  }}
+  up-stack-id: {{ $ordinal | quote }}
+labels:
+  {{
+    include "accelleran.cu-up.labels"
+      (dict
+        "top" $
+        "values" $values
+      )
+    | nindent 2
+  }}
   up-stack-id: {{ $ordinal | quote }}
 {{- end -}}

--- a/charts/cu-up/templates/service-gtp-u.yaml
+++ b/charts/cu-up/templates/service-gtp-u.yaml
@@ -20,6 +20,9 @@ values:
 
 serviceName: {{ (include "accelleran.cu-up.gtp-u.service.name" (list $ $ordinal)) | quote }}
 
+labels:
+  {{ include "accelleran.common.labels" (dict "top" $ "values" $values) | nindent 2 }}
+  up-stack-id: {{ $ordinal | quote }}
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
   app.kubernetes.io/component: {{ $values.component }}

--- a/charts/cu-up/templates/service-gtp-u.yaml
+++ b/charts/cu-up/templates/service-gtp-u.yaml
@@ -22,5 +22,6 @@ serviceName: {{ (include "accelleran.cu-up.gtp-u.service.name" (list $ $ordinal)
 
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
+  app.kubernetes.io/component: {{ $values.component }}
   up-stack-id: {{ $ordinal | quote }}
 {{- end -}}

--- a/charts/cu-up/templates/service-gtp-u.yaml
+++ b/charts/cu-up/templates/service-gtp-u.yaml
@@ -22,6 +22,5 @@ serviceName: {{ (include "accelleran.cu-up.gtp-u.service.name" (list $ $ordinal)
 
 selectorLabels:
   {{ include "accelleran.common.selectorLabels" (dict "top" $ "values" $values) | nindent 2 }}
-  app.kubernetes.io/component: {{ $values.component }}
   up-stack-id: {{ $ordinal | quote }}
 {{- end -}}

--- a/charts/cu-up/templates/statefulset-cu-up.yaml
+++ b/charts/cu-up/templates/statefulset-cu-up.yaml
@@ -17,10 +17,9 @@ values:
   }}
 
 selectorLabels:
-  {{ include "accelleran.common.selectorLabels" (dict "top" $) | nindent 2 }}
-  app.kubernetes.io/component: {{ $.Values.component }}
+  {{ include "accelleran.cu-up.selectorLabels" (dict "top" $) | nindent 2 }}
 labels:
-  {{ include "accelleran.common.labels" (dict "top" $) | nindent 2 }}
+  {{ include "accelleran.cu-up.labels" (dict "top" $) | nindent 2 }}
 
 initContainers:
 - {{ fromYaml (include "accelleran.common.init.nats" (fromYaml (include "accelleran.cu-up.init.args" .))) | toYaml | nindent 2 }}


### PR DESCRIPTION
While rendering the cu-up Helm chart, some resources contained duplicate app.kubernetes.io/component labels, causing YAML validation errors and preventing Flux from installing the HelmRelease in the new SMO.