### PR TITLE
revert(deps): downgrade dependency python to 3.13

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
           check-latest: true
 
       - name: Set up chart-testing
@@ -74,7 +74,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
           check-latest: true
 
       - name: Set up chart-testing
@@ -120,7 +120,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
           check-latest: true
 
       - name: Set up chart-testing


### PR DESCRIPTION
Reverts accelleran/helm-charts#1563

Python 3.14 breaks `ct lint`.