### PR TITLE
fix(drax): switch OAuth2-proxy to relative paths for dynamic host-based authentication

### DIFF
--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -1080,10 +1080,12 @@ keycloak:
   httpRelativePath: "/keycloak/"
 
   extraEnvVars:
+    # Set canonical hostname to ensure consistent JWT issuer claim regardless of how
+    # Keycloak is accessed (external via ingress vs internal via service). This prevents
+    # issuer mismatch errors during OAuth2 token validation when the browser accesses
+    # Keycloak externally but oauth2-proxy validates tokens using the internal hostname.
     - name: KC_HOSTNAME
       value: "{{ $.Release.Name }}-keycloak.{{ $.Release.Namespace }}"
-    - name: KC_HTTP_RELATIVE_PATH
-      value: "/keycloak"
 
   ingress:
     # use ingress in extraDeploy as it allows to leave out the host

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -328,7 +328,7 @@ dashboard:
     enabled: true
     className: drax
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
@@ -360,7 +360,7 @@ network-state-monitor:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -386,7 +386,7 @@ service-monitor:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -412,7 +412,7 @@ service-orchestrator:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -443,7 +443,7 @@ config-api:
     enabled: true
     className: drax
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -673,7 +673,7 @@ pm-counters:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -986,8 +986,14 @@ oauth2-proxy:
 
       provider = "oidc"
       provider_display_name = "Accelleran dRAX"
-      oidc_issuer_url = "https://{{ $.Values.global.domain | default $.Values.global.ipAddress }}/keycloak/realms/drax"
+      skip_oidc_discovery = true
+      oidc_issuer_url = "http://{{ $.Release.Name }}-keycloak.{{ $.Release.Namespace }}/keycloak/realms/drax"
+      oidc_jwks_url = "http://{{ $.Release.Name }}-keycloak.{{ $.Release.Namespace }}/keycloak/realms/drax/protocol/openid-connect/certs"
+      login_url = "/keycloak/realms/drax/protocol/openid-connect/auth"
+      redeem_url = "/keycloak/realms/drax/protocol/openid-connect/token"
+      profile_url = "/keycloak/realms/drax/protocol/openid-connect/userinfo"
       redirect_url = "/oauth2/callback"
+      relative_redirect_url = true
       email_domains = [ "*" ]
       insecure_oidc_allow_unverified_email = true
       scope = "openid email profile"
@@ -1072,6 +1078,12 @@ keycloak:
 
   proxyHeaders: "xforwarded"
   httpRelativePath: "/keycloak/"
+
+  extraEnvVars:
+    - name: KC_HOSTNAME
+      value: "{{ $.Release.Name }}-keycloak.{{ $.Release.Namespace }}"
+    - name: KC_HTTP_RELATIVE_PATH
+      value: "/keycloak"
 
   ingress:
     # use ingress in extraDeploy as it allows to leave out the host
@@ -1233,7 +1245,7 @@ grafana:
     enabled: true
     ingressClassName: "drax"
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k


### PR DESCRIPTION
Configure OAuth2-proxy to use relative endpoint paths and internal service URLs instead of hardcoded external addresses, enabling authentication to work seamlessly regardless of the hostname or IP used to access the system.

Issues resolved:
- Eliminates oauth2-proxy crash loops during deployment caused by OIDC discovery race conditions when trying to reach Keycloak via external ingress URL
- Prevents hostname changes in user's browser (e.g., accessing via custom DNS drax.example.com would redirect to hardcoded IP 192.168.61.51)
- Enables support for multiple access methods (IP, domain names, etc.) without JWT issuer mismatch errors
- Removes dependency on hairpin NAT for pod-to-external-LoadBalancer communication

Changes:
- Configure oauth2-proxy to skip OIDC discovery and use explicit relative paths (login_url, redeem_url, profile_url) with relative_redirect_url enabled
- Use internal Keycloak service URL for oidc_issuer_url and oidc_jwks_url
- Set Keycloak KC_HOSTNAME to internal service name for consistent JWT issuer
- Update ingress auth-url to use internal oauth2-proxy service endpoint