### PR TITLE
fix: adjust arguments for latest yq version

### DIFF
--- a/charts/du/templates/statefulset.yaml
+++ b/charts/du/templates/statefulset.yaml
@@ -73,7 +73,7 @@ command:
       sleep 5
     done
 
-    yq --yaml-output ".f1u.socket = {bind_addr: '$POD_IP', ext_addr: '$external_address'}" "/etc/input-config/config.yml" >"/etc/output-config/config.yml"
+    yq eval -o yaml ".f1u.socket.bind_addr = \"$POD_IP\" | .f1u.socket.ext_addr = \"$external_address\"" "/etc/input-config/config.yml" >"/etc/output-config/config.yml"
 
 env:
   - name: POD_IP

--- a/charts/du/templates/statefulset.yaml
+++ b/charts/du/templates/statefulset.yaml
@@ -73,7 +73,7 @@ command:
       sleep 5
     done
 
-    yq eval -o yaml ".f1u.socket.bind_addr = \"$POD_IP\" | .f1u.socket.ext_addr = \"$external_address\"" "/etc/input-config/config.yml" >"/etc/output-config/config.yml"
+    yq eval -o yaml ".f1u.socket[0].bind_addr = \"$POD_IP\" | .f1u.socket[0].ext_addr = \"$external_address\"" "/etc/input-config/config.yml" >"/etc/output-config/config.yml"
 
 env:
   - name: POD_IP

--- a/charts/du/templates/statefulset.yaml
+++ b/charts/du/templates/statefulset.yaml
@@ -73,7 +73,7 @@ command:
       sleep 5
     done
 
-    yq eval -o yaml ".f1u.socket[0].bind_addr = \"$POD_IP\" | .f1u.socket[0].ext_addr = \"$external_address\"" "/etc/input-config/config.yml" >"/etc/output-config/config.yml"
+    yq eval -o yaml ".f1u.socket = [{\"bind_addr\": \"$POD_IP\", \"ext_addr\": \"$external_address\"}]" "/etc/input-config/config.yml" >"/etc/output-config/config.yml"
 
 env:
   - name: POD_IP


### PR DESCRIPTION
The acc-generic-img container image (0.10.0-k8s-1.29) no longer supports the `--yaml-output` flag.
