### PR TITLE
feat(drax): support OAuth2/Keycloak authentication via both IP and domain

### DIFF
--- a/charts/drax/templates/job-keycloak-init.yaml
+++ b/charts/drax/templates/job-keycloak-init.yaml
@@ -46,8 +46,10 @@ env:
   - name: HELM_RELEASE_NAMESPACE
     value: {{ $.Release.Namespace }}
 
-  - name: DRAX_ENDPOINT
-    value: {{ $.Values.global.domain | default $.Values.global.ipAddress }}
+  - name: DRAX_DOMAIN
+    value: "{{ $.Values.global.domain }}"
+  - name: DRAX_IP
+    value: "{{ $.Values.global.ipAddress }}"
 
   - name: KUBERNETES_NAMESPACE
     value: {{ $.Release.Namespace }}

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -328,7 +328,7 @@ dashboard:
     enabled: true
     className: drax
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
@@ -360,7 +360,7 @@ network-state-monitor:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -386,7 +386,7 @@ service-monitor:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -412,7 +412,7 @@ service-orchestrator:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -443,7 +443,7 @@ config-api:
     enabled: true
     className: drax
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -673,7 +673,7 @@ pm-counters:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
       nginx.ingress.kubernetes.io/proxy-buffering: 'on'
@@ -1253,7 +1253,7 @@ grafana:
     enabled: true
     ingressClassName: "drax"
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-url: "http://{{ $.Release.Name }}-oauth2-proxy.{{ $.Release.Namespace }}.svc.cluster.local/oauth2/auth"
       nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 256k

--- a/charts/drax/values.yaml
+++ b/charts/drax/values.yaml
@@ -986,14 +986,29 @@ oauth2-proxy:
 
       provider = "oidc"
       provider_display_name = "Accelleran dRAX"
-      oidc_issuer_url = "https://{{ $.Values.global.domain | default $.Values.global.ipAddress }}/keycloak/realms/drax"
-      redirect_url = "/oauth2/callback"
+
       email_domains = [ "*" ]
       insecure_oidc_allow_unverified_email = true
       scope = "openid email profile"
 
+      # Manually configure OIDC endpoints - global.domain may not be resolvable inside cluster
+      # use internal service DNS where possible (faster, no ingress overhead)
+      skip_oidc_discovery = true
+      oidc_issuer_url = "https://{{ $.Values.global.domain | default $.Values.global.ipAddress }}/keycloak/realms/drax"
+      login_url = "/keycloak/realms/drax/protocol/openid-connect/auth" # redirect browser with relative path
+      redirect_url = "/oauth2/callback"
+      redeem_url = "http://{{ $.Release.Name }}-keycloak.{{ $.Release.Namespace }}/keycloak/realms/drax/protocol/openid-connect/token"
+      oidc_jwks_url = "http://{{ $.Release.Name }}-keycloak.{{ $.Release.Namespace }}/keycloak/realms/drax/protocol/openid-connect/certs"
+
+      # Skip issuer verification when both domain and IP are configured, as issuer will be dynamic.
+      # This is safe because:
+      #   1) Token signature validation still occurs via oidc_jwks_url, and
+      #   2) Both domain and IP are trusted origins.
+      {{- if and $.Values.global.domain $.Values.global.ipAddress }}
+      insecure_oidc_skip_issuer_verification = true
+      {{- end }}
+
       whitelist_domains = [ {{ with $.Values.global.domain }}"{{ . }}",".{{ . }}",{{ end }}"{{ $.Values.global.ipAddress }}" ]
-      cookie_domains = [ {{ with $.Values.global.domain }}"{{ . }}",".{{ . }}",{{ end }}"{{ $.Values.global.ipAddress }}" ]
 
       cookie_csrf_per_request = true
       cookie_csrf_expire = "5m"
@@ -1072,6 +1087,11 @@ keycloak:
 
   proxyHeaders: "xforwarded"
   httpRelativePath: "/keycloak/"
+
+  # Configure Keycloak hostname: disable strict hostname checking to allow access via both domain and IP
+  extraEnvVars:
+    - name: KC_HOSTNAME_STRICT
+      value: "false"
 
   ingress:
     # use ingress in extraDeploy as it allows to leave out the host


### PR DESCRIPTION
Enable flexible authentication access patterns by supporting both IP-only
and domain-based deployments, as well as mixed access (domain configured
but accessed via IP).

This also resolves issues where dRAX is configured with a domain but the
domain is not resolvable from within the cluster.

Changes:
- Configure Keycloak with KC_HOSTNAME_STRICT=false to allow dynamic issuer
  based on request hostname
- Use skip_oidc_discovery in oauth2-proxy with manual endpoint configuration:
  - login_url uses relative path (resolved by browser)
  - redeem_url and oidc_jwks_url use internal service DNS for efficiency
- Enable insecure_oidc_skip_issuer_verification when both domain and IP
  are configured to handle issuer mismatch
- Register both domain and IP redirect URIs in Keycloak client
- Remove cookie_domains restriction to allow cookies on both IP and domain

This enables three deployment scenarios:
1. IP-only: Works without domain configuration
2. Domain with domain access: Standard domain-based deployment
3. Domain with IP access: Allows IP fallback when domain is configured