### PR TITLE
fix: fix api url in xapp hello world helm chart

### DIFF
--- a/charts/xapp-hello-world/Chart.yaml
+++ b/charts/xapp-hello-world/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: xapp-hello-world
 description: A Helm chart for Accelleran dRAX xApp
 type: application
-version: 6.0.0
+version: 6.0.1
 # renovate: image=accelleran/xapp-framework-package
 appVersion: 6.0.0
 dependencies:

--- a/charts/xapp-hello-world/Chart.yaml
+++ b/charts/xapp-hello-world/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: xapp-hello-world
 description: A Helm chart for Accelleran dRAX xApp
 type: application
-version: 6.0.1
+version: 6.0.0
 # renovate: image=accelleran/xapp-framework-package
 appVersion: 6.0.0
 dependencies:

--- a/charts/xapp-hello-world/values.yaml
+++ b/charts/xapp-hello-world/values.yaml
@@ -49,7 +49,7 @@ xappFrameworkConfig:
 xappEndpoints:
   REDIS_URL: "redis://{{ .Release.Name }}-xapp-redis.{{ .Release.Namespace }}:6379"
   KAFKA_URL: "kafka://{{ .Values.global.kubeIp }}:31090"
-  API_URL: "http://{{ .Values.global.kubeIp }}:31315"
+  API_URL: "http://drax-dashboard:5000"
   NATS_URL: "nats://{{ .Values.global.kubeIp }}:31100"
   NATS_URL_5G: "nats://{{ .Values.global.kubeIp }}:31100"
   PROMETHEUS_URL: "http://{{ .Values.global.kubeIp }}:30304"


### PR DESCRIPTION
Fixing API_URL for xApp Dev env to use static dashboard url. This needs to be properly fixed in the Service Orchestrator, to inject the correct value rather then hardcoding. This will break if someone uses a different Release Name of dRAX on installation time, but its a quick and dirty fix that we just need right now. It is backwards compatible with dRAX 13 as well.
