### PR TITLE
chore(drax): exclude CHANGELOG and RELEASE_NOTES from the chart package

### DIFF
--- a/charts/drax/.helmignore
+++ b/charts/drax/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+# Large docs that inflate the chart package
+CHANGELOG.md
+RELEASE_NOTES.md


### PR DESCRIPTION
## Summary
- Exclude `CHANGELOG.md` and `RELEASE_NOTES.md` from the packaged drax chart via `.helmignore`.
- These files inflate the chart past what Helm can store in the release Secret, which can block installation.

## Test plan
- [ ] `helm package charts/drax` and confirm the tarball does not contain `CHANGELOG.md` or `RELEASE_NOTES.md`
- [ ] Confirm `helm install` / `helm template` still works (configuration files and templates are unchanged)

Made with [Cursor](https://cursor.com)